### PR TITLE
support lazy init for service proxy when biz is still installing

### DIFF
--- a/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/service/ServiceProxyFactory.java
+++ b/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/service/ServiceProxyFactory.java
@@ -105,7 +105,8 @@ public class ServiceProxyFactory {
                                     Class<?> clientType) {
         Biz biz = determineMostSuitableBiz(bizName, bizVersion);
 
-        if (biz == null) {
+        // biz not exist or not install finished
+        if (biz == null || biz.getBizState() == BizState.RESOLVED) {
             return null;
         } else if (biz.getBizState() != BizState.ACTIVATED
                    && biz.getBizState() != BizState.DEACTIVATED) {
@@ -221,7 +222,7 @@ public class ServiceProxyFactory {
                 return null;
             }
             biz = bizList.stream().filter(it -> BizState.ACTIVATED == it.getBizState()).findFirst()
-                .get();
+                .orElse(null);
         } else {
             biz = ArkClient.getBizManagerService().getBiz(moduleName, moduleVersion);
         }

--- a/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/service/SpringServiceInvoker.java
+++ b/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/service/SpringServiceInvoker.java
@@ -102,8 +102,11 @@ public class SpringServiceInvoker implements MethodInterceptor {
         if (biz == null) {
             throw new BizRuntimeException(E100003,
                 String.format("biz %s:%s does not exist when called", bizName, bizVersion));
-        }
-        if (BizState.ACTIVATED != biz.getBizState() && BizState.DEACTIVATED != biz.getBizState()) {
+        } else if (biz.getBizState() == BizState.RESOLVED) {
+            throw new BizRuntimeException(E100003,
+                String.format("biz %s:%s is still installing when called", bizName, bizVersion));
+        } else if (BizState.ACTIVATED != biz.getBizState()
+                   && BizState.DEACTIVATED != biz.getBizState()) {
             throw new BizRuntimeException(E100004, String.format("biz %s:%s state %s is not valid",
                 bizName, bizVersion, biz.getBizState()));
         }

--- a/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/SpringServiceAndBeanFinderTest.java
+++ b/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/SpringServiceAndBeanFinderTest.java
@@ -114,7 +114,7 @@ public class SpringServiceAndBeanFinderTest {
         Mockito.when(biz1.getBizState()).thenReturn(BizState.RESOLVED);
         Exception exception1 = Assert.assertThrows(BizRuntimeException.class,
             () -> moduleBean.test());
-        Assert.assertEquals("biz biz1:version1 state resolved is not valid",
+        Assert.assertEquals("biz biz1:version1 is still installing when called",
             exception1.getMessage());
     }
 
@@ -188,12 +188,12 @@ public class SpringServiceAndBeanFinderTest {
     @Test
     public void testSpringServiceFinderWithoutBiz() {
         Mockito.when(bizManagerService.getBiz("biz1", "version1")).thenReturn(biz1);
-        Mockito.when(biz1.getBizState()).thenReturn(BizState.RESOLVED);
+        Mockito.when(biz1.getBizState()).thenReturn(BizState.UNRESOLVED);
         Exception exception1 = Assert.assertThrows(BizRuntimeException.class, () -> {
             SpringServiceFinder.getModuleService("biz1", "version1", "moduleBean",
                 ModuleBean.class);
         });
-        Assert.assertEquals("biz biz1:version1 state resolved is not valid",
+        Assert.assertEquals("biz biz1:version1 state unresolved is not valid",
             exception1.getMessage());
 
         Object newModuleBean = null;


### PR DESCRIPTION
fix https://github.com/koupleless/koupleless/issues/241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
  - Improved stability by handling cases where the `biz` object is null or in a resolved state, preventing potential errors.
  - Enhanced logic to determine the most suitable `biz`, ensuring more robust and error-free service selection.
  - Updated test case to reflect changes in expected `BizState` for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->