### PR TITLE
fill springboot applicationcontext earlier

### DIFF
--- a/.github/workflows/koupleless_runtime_snapshot_2.0.x.yml
+++ b/.github/workflows/koupleless_runtime_snapshot_2.0.x.yml
@@ -84,12 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: 'runtime-2.0.x'
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          ref: 'runtime-2.0.x'
           java-version: '17'
           distribution: 'temurin'
           cache: maven

--- a/.github/workflows/koupleless_runtime_snapshot_2.1.x.yml
+++ b/.github/workflows/koupleless_runtime_snapshot_2.1.x.yml
@@ -84,12 +84,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: 'runtime-2.1.x'
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          ref: 'runtime-2.1.x'
           java-version: '17'
           distribution: 'temurin'
           cache: maven

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
@@ -21,10 +21,13 @@ import com.alipay.sofa.koupleless.common.service.ArkAutowiredBeanPostProcessor;
 import com.alipay.sofa.koupleless.common.BizRuntimeContextRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 
 /**
  * <p>BaseRuntimeAutoConfiguration class.</p>
@@ -60,6 +63,16 @@ public class BaseRuntimeAutoConfiguration {
             .getBizRuntimeContextByClassLoader(classLoader);
         bizRuntimeContext.setRootApplicationContext(applicationContext);
         return bizRuntimeContext;
+    }
+
+    @EventListener
+    public void onApplicationStartedEvent(ApplicationStartedEvent event) {
+        // 获取 ApplicationContext
+        ConfigurableApplicationContext applicationContext = event.getApplicationContext();
+        ClassLoader classLoader = applicationContext.getClassLoader();
+        BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
+                .getBizRuntimeContextByClassLoader(classLoader);
+        bizRuntimeContext.setRootApplicationContext(applicationContext);
     }
 
     /**

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
@@ -71,7 +71,7 @@ public class BaseRuntimeAutoConfiguration {
         ConfigurableApplicationContext applicationContext = event.getApplicationContext();
         ClassLoader classLoader = applicationContext.getClassLoader();
         BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
-                .getBizRuntimeContextByClassLoader(classLoader);
+            .getBizRuntimeContextByClassLoader(classLoader);
         bizRuntimeContext.setRootApplicationContext(applicationContext);
     }
 

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfiguration.java
@@ -16,18 +16,11 @@
  */
 package com.alipay.sofa.koupleless.plugin;
 
-import com.alipay.sofa.koupleless.common.BizRuntimeContext;
 import com.alipay.sofa.koupleless.common.service.ArkAutowiredBeanPostProcessor;
-import com.alipay.sofa.koupleless.common.BizRuntimeContextRegistry;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
-import org.springframework.context.ApplicationContext;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.event.EventListener;
 
 /**
  * <p>BaseRuntimeAutoConfiguration class.</p>
@@ -38,43 +31,6 @@ import org.springframework.context.event.EventListener;
  */
 @Configuration
 public class BaseRuntimeAutoConfiguration {
-
-    /**
-     * <p>bizRuntimeContext.</p>
-     *
-     * @param applicationContext a {@link org.springframework.context.ApplicationContext} object
-     * @return a {@link com.alipay.sofa.koupleless.common.BizRuntimeContext} object
-     */
-    @Bean
-    @ConditionalOnMissingClass("com.alipay.sofa.koupleless.test.suite.biz.TestBizClassLoader")
-    public BizRuntimeContext bizRuntimeContext(ApplicationContext applicationContext) {
-        ClassLoader classLoader = applicationContext.getClassLoader();
-        BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
-            .getBizRuntimeContextByClassLoader(classLoader);
-        bizRuntimeContext.setRootApplicationContext(applicationContext);
-        return bizRuntimeContext;
-    }
-
-    @Bean(name = "bizRuntimeContext")
-    @ConditionalOnClass(name = "com.alipay.sofa.koupleless.test.suite.biz.TestBizClassLoader")
-    public BizRuntimeContext bizRuntimeContextIntegrationTest(ApplicationContext applicationContext) {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
-            .getBizRuntimeContextByClassLoader(classLoader);
-        bizRuntimeContext.setRootApplicationContext(applicationContext);
-        return bizRuntimeContext;
-    }
-
-    @EventListener
-    public void onApplicationStartedEvent(ApplicationStartedEvent event) {
-        // 获取 ApplicationContext
-        ConfigurableApplicationContext applicationContext = event.getApplicationContext();
-        ClassLoader classLoader = applicationContext.getClassLoader();
-        BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
-            .getBizRuntimeContextByClassLoader(classLoader);
-        bizRuntimeContext.setRootApplicationContext(applicationContext);
-    }
-
     /**
      * <p>arkAutowiredBeanPostProcessor.</p>
      *

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/spring/BizApplicationContextInitializer.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/spring/BizApplicationContextInitializer.java
@@ -1,0 +1,18 @@
+package com.alipay.sofa.koupleless.plugin.spring;
+
+import com.alipay.sofa.koupleless.common.BizRuntimeContext;
+import com.alipay.sofa.koupleless.common.BizRuntimeContextRegistry;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+public class BizApplicationContextInitializer
+        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        ClassLoader classLoader = applicationContext.getClassLoader();
+        BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
+                .getBizRuntimeContextByClassLoader(classLoader);
+        bizRuntimeContext.setRootApplicationContext(applicationContext);
+    }
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/spring/BizApplicationContextInitializer.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/spring/BizApplicationContextInitializer.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.alipay.sofa.koupleless.plugin.spring;
 
 import com.alipay.sofa.koupleless.common.BizRuntimeContext;
@@ -5,14 +21,14 @@ import com.alipay.sofa.koupleless.common.BizRuntimeContextRegistry;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 
-public class BizApplicationContextInitializer
-        implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+public class BizApplicationContextInitializer implements
+                                              ApplicationContextInitializer<ConfigurableApplicationContext> {
 
     @Override
     public void initialize(ConfigurableApplicationContext applicationContext) {
         ClassLoader classLoader = applicationContext.getClassLoader();
         BizRuntimeContext bizRuntimeContext = BizRuntimeContextRegistry
-                .getBizRuntimeContextByClassLoader(classLoader);
+            .getBizRuntimeContextByClassLoader(classLoader);
         bizRuntimeContext.setRootApplicationContext(applicationContext);
     }
 }

--- a/koupleless-base-plugin/src/main/resources/META-INF/spring.factories
+++ b/koupleless-base-plugin/src/main/resources/META-INF/spring.factories
@@ -10,3 +10,6 @@ org.springframework.boot.env.EnvironmentPostProcessor=\
 # Auto Configuration Import Filters
 org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
   com.alipay.sofa.koupleless.plugin.spring.SkipAutoConfigurationImportFilter
+
+org.springframework.context.ApplicationContextInitializer=\
+  com.alipay.sofa.koupleless.plugin.spring.BizApplicationContextInitializer

--- a/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfigurationTest.java
+++ b/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/BaseRuntimeAutoConfigurationTest.java
@@ -49,7 +49,6 @@ public class BaseRuntimeAutoConfigurationTest {
     @Test
     public void test() {
         contextRunner.run(context -> {
-            Assertions.assertThat(context).hasSingleBean(BizRuntimeContext.class);
             Assertions.assertThat(context).hasSingleBean(ArkAutowiredBeanPostProcessor.class);
         });
     }

--- a/koupleless-ext/koupleless-test-suite/pom.xml
+++ b/koupleless-ext/koupleless-test-suite/pom.xml
@@ -88,6 +88,16 @@
         <dependency>
             <groupId>com.alipay.sofa.koupleless</groupId>
             <artifactId>arklet-core</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
 

--- a/koupleless-ext/koupleless-test-suite/src/main/java/com/alipay/sofa/koupleless/test/suite/biz/TestBootstrap.java
+++ b/koupleless-ext/koupleless-test-suite/src/main/java/com/alipay/sofa/koupleless/test/suite/biz/TestBootstrap.java
@@ -155,7 +155,7 @@ public class TestBootstrap {
             BizModel bizModel = new BizModel();
             bizModel.setBizName("master biz");
             bizModel.setBizVersion("TEST");
-            bizModel.setClassLoader(baseClassLoader.getParent());
+            bizModel.setClassLoader(baseClassLoader);
             bizModel.setBizState(BizState.RESOLVED);
             ArkClient.setMasterBiz(bizModel);
             ArkClient.getBizManagerService().registerBiz(bizModel);

--- a/koupleless-ext/koupleless-test-suite/src/main/java/com/alipay/sofa/koupleless/test/suite/spring/base/BaseClassLoader.java
+++ b/koupleless-ext/koupleless-test-suite/src/main/java/com/alipay/sofa/koupleless/test/suite/spring/base/BaseClassLoader.java
@@ -33,6 +33,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.jar.JarFile;
@@ -139,9 +140,21 @@ public class BaseClassLoader extends URLClassLoader {
 
     @Override
     public URL getResource(String name) {
-        URL resource = higherPriorityResourceClassLoader.getResource(name);
-        resource = resource != null ? resource : super.getResource(name);
-        return resource;
+        try {
+            Enumeration<URL> urlEnumeration = getResources(name);
+            // to List
+            List<URL> urls = new ArrayList<>();
+            while (urlEnumeration.hasMoreElements()) {
+                urls.add(urlEnumeration.nextElement());
+            }
+            // if there are multiple resources, return the first one
+            if (urls.size() > 0) {
+                return urls.get(0);
+            }
+            return null;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.2.2</revision>
+        <revision>1.2.3-SNAPSHOT</revision>
         <sofa.ark.version>2.2.11</sofa.ark.version>
         <spring.boot.version>2.7.15</spring.boot.version>
         <project.encoding>UTF-8</project.encoding>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new class `BizApplicationContextInitializer` for initializing `BizRuntimeContext` with the application context.

- **Improvements**
	- Enhanced application startup by adding an event listener method in `BaseRuntimeAutoConfiguration` to handle `ApplicationStartedEvent`.
	- Streamlined resource handling in `BaseClassLoader` to return the first available resource.

- **Build and Dependencies**
	- Updated GitHub Actions workflows to simplify JDK 17 setup by removing specific references.
	- Modified `pom.xml` in `koupleless-test-suite` to exclude certain dependencies (logback-classic, logback-core).

- **Bug Fixes**
	- Corrected `ClassLoader` initialization for `BizModel` in `TestBootstrap` to ensure proper setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->