### PR TITLE
StaticBatchInstallEventListener被实例化多次时防止重复部署

### DIFF
--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListener.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListener.java
@@ -20,7 +20,6 @@ import com.alipay.sofa.ark.api.ClientResponse;
 import com.alipay.sofa.ark.api.ResponseCode;
 import com.alipay.sofa.ark.common.util.StringUtils;
 import com.alipay.sofa.koupleless.arklet.core.ArkletComponentRegistry;
-import com.alipay.sofa.koupleless.arklet.core.common.log.ArkletLogger;
 import com.alipay.sofa.koupleless.arklet.core.common.log.ArkletLoggerFactory;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse;
@@ -29,13 +28,9 @@ import com.alipay.sofa.koupleless.common.util.ArkUtils;
 import com.google.common.base.Preconditions;
 import lombok.SneakyThrows;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ApplicationContextEvent;
-import org.springframework.context.event.ContextRefreshedEvent;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -47,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class StaticBatchInstallEventListener implements ApplicationListener<ApplicationReadyEvent> {
 
     // 合并部署是否已经完成，防止重复执行。
-    private AtomicBoolean isBatchdDeployed = new AtomicBoolean(false);
+    private static final AtomicBoolean isBatchedDeployed = new AtomicBoolean(false);
 
     /**
      * <p>batchDeployFromLocalDir.</p>
@@ -55,7 +50,7 @@ public class StaticBatchInstallEventListener implements ApplicationListener<Appl
     @SneakyThrows
     public void batchDeployFromLocalDir() {
         String absolutePath = System.getProperty("com.alipay.sofa.ark.static.biz.dir");
-        if (StringUtils.isEmpty(absolutePath) || isBatchdDeployed.get()) {
+        if (StringUtils.isEmpty(absolutePath) || isBatchedDeployed.get()) {
             return;
         }
         ArkletLoggerFactory.getDefaultLogger().info("start to batch deploy from local dir:{}",
@@ -71,7 +66,7 @@ public class StaticBatchInstallEventListener implements ApplicationListener<Appl
                 entry.getKey(), entry.getValue().getCode().toString(),
                 entry.getValue().getMessage());
         }
-        isBatchdDeployed.set(true);
+        isBatchedDeployed.set(true);
         Preconditions.checkState(batchInstallResponse.getCode() == ResponseCode.SUCCESS,
             "batch deploy failed!");
     }

--- a/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
+++ b/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
@@ -121,16 +121,16 @@ public class StaticBatchInstallEventListenerTest {
         BatchInstallResponse response = null;
         ApplicationReadyEvent event = null;
         componentRegistryMockedStatic.when(ArkletComponentRegistry::getOperationServiceInstance)
-                .thenReturn(operationService);
+            .thenReturn(operationService);
 
         response = BatchInstallResponse.builder().code(ResponseCode.SUCCESS)
-                .bizUrlToResponse(new HashMap<>()).build();
+            .bizUrlToResponse(new HashMap<>()).build();
 
         response.getBizUrlToResponse().put("foo", new ClientResponse());
         response.getBizUrlToResponse().get("foo").setCode(ResponseCode.SUCCESS);
 
         doReturn(response).when(operationService)
-                .batchInstall(BatchInstallRequest.builder().bizDirAbsolutePath("/path/to/dir").build());
+            .batchInstall(BatchInstallRequest.builder().bizDirAbsolutePath("/path/to/dir").build());
 
         event = mock(ApplicationReadyEvent.class);
         try (MockedStatic<ArkUtils> arkUtilsMockedStatic = Mockito.mockStatic(ArkUtils.class)) {

--- a/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
+++ b/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
@@ -81,7 +81,7 @@ public class StaticBatchInstallEventListenerTest {
 
     @SneakyThrows
     private void resetIsBatchedDeployed() {
-        Field field = StaticBatchInstallEventListener.class.getDeclaredField("isBatchedDeployed");
+        Field field = StaticBatchInstallEventListener.class.getDeclaredField("isBatchDeployed");
         field.setAccessible(true);
         AtomicBoolean isBatchedDeployed = (AtomicBoolean) field.get(null);
         isBatchedDeployed.set(false);

--- a/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
+++ b/koupleless-base-plugin/src/test/java/com/alipay/sofa/koupleless/plugin/manager/listener/StaticBatchInstallEventListenerTest.java
@@ -40,7 +40,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.event.ContextRefreshedEvent;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -73,7 +75,16 @@ public class StaticBatchInstallEventListenerTest {
     @After
     public void afterTest() {
         componentRegistryMockedStatic.close();
+        resetIsBatchedDeployed();
         System.clearProperty("com.alipay.sofa.ark.static.biz.dir");
+    }
+
+    @SneakyThrows
+    private void resetIsBatchedDeployed() {
+        Field field = StaticBatchInstallEventListener.class.getDeclaredField("isBatchedDeployed");
+        field.setAccessible(true);
+        AtomicBoolean isBatchedDeployed = (AtomicBoolean) field.get(null);
+        isBatchedDeployed.set(false);
     }
 
     @SneakyThrows


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Corrected a field name from `isBatchdDeployed` to `isBatchedDeployed` for clarity and consistency.

- **Tests**
  - Enhanced testing for batch deployment with additional instance validation to ensure the integrity of the batch installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->