### PR TITLE
Dev lipeng installbiz set biz alias

### DIFF
--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
@@ -78,15 +78,11 @@ public class InstallBizHandler extends
     }
 
     private InstallRequest convertInstallRequest(Input input) {
-        return InstallRequest.builder()
-            .bizName(input.getBizName())
-            .bizVersion(input.getBizVersion())
-            .bizUrl(input.getBizUrl())
-            .args(input.getArgs())
+        return InstallRequest.builder().bizName(input.getBizName())
+            .bizVersion(input.getBizVersion()).bizUrl(input.getBizUrl()).args(input.getArgs())
             .envs(input.getEnvs())
             .useUninstallThenInstallStrategy(input.isUseUninstallThenInstallStrategy())
-            .bizAlias(input.getBizAlias())
-            .build();
+            .bizAlias(input.getBizAlias()).build();
     }
 
     private MemoryPoolMXBean getMetaSpaceMXBean() {

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
@@ -33,6 +33,7 @@ import com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletRuntimeExce
 import com.alipay.sofa.koupleless.arklet.core.common.exception.CommandValidationException;
 import com.alipay.sofa.koupleless.arklet.core.common.log.ArkletLogger;
 import com.alipay.sofa.koupleless.arklet.core.common.log.ArkletLoggerFactory;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -63,9 +64,7 @@ public class InstallBizHandler extends
         long startSpace = metaSpaceMXBean.getUsage().getUsed();
         try {
             InstallBizClientResponse installBizClientResponse = convertClientResponse(
-                getOperationService().install(input.getBizName(), input.getBizVersion(),
-                    input.getBizUrl(), input.getArgs(), input.getEnvs(),
-                    input.isUseUninstallThenInstallStrategy()));
+                getOperationService().install(convertInstallRequest(input)));
             installBizClientResponse
                 .setElapsedSpace(metaSpaceMXBean.getUsage().getUsed() - startSpace);
             if (ResponseCode.SUCCESS.equals(installBizClientResponse.getCode())) {
@@ -76,6 +75,18 @@ public class InstallBizHandler extends
         } catch (Throwable e) {
             throw new ArkletRuntimeException(e);
         }
+    }
+
+    private InstallRequest convertInstallRequest(Input input) {
+        return InstallRequest.builder()
+            .bizName(input.getBizName())
+            .bizVersion(input.getBizVersion())
+            .bizUrl(input.getBizUrl())
+            .args(input.getArgs())
+            .envs(input.getEnvs())
+            .useUninstallThenInstallStrategy(input.isUseUninstallThenInstallStrategy())
+            .bizAlias(input.getBizAlias())
+            .build();
     }
 
     private MemoryPoolMXBean getMetaSpaceMXBean() {
@@ -165,6 +176,8 @@ public class InstallBizHandler extends
          * default value is true, if set false, installing the new biz, the old biz will be uninstalled
          */
         private boolean             useUninstallThenInstallStrategy = true;
+
+        private String              bizAlias;
     }
 
     @Getter

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/InstallRequest.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/InstallRequest.java
@@ -1,0 +1,31 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.common.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: InstallRequest.java, v 0.1 2024年07月01日 20:02 立蓬 Exp $
+ */
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Builder
+public class InstallRequest {
+    String bizName;
+    String bizVersion;
+    String bizUrl;
+    String[] args;
+    Map<String, String> envs;
+    boolean useUninstallThenInstallStrategy;
+    String bizAlias;
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/InstallRequest.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/InstallRequest.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.common.model;
 
@@ -21,11 +33,11 @@ import java.util.Map;
 @Data
 @Builder
 public class InstallRequest {
-    String bizName;
-    String bizVersion;
-    String bizUrl;
-    String[] args;
+    String              bizName;
+    String              bizVersion;
+    String              bizUrl;
+    String[]            args;
     Map<String, String> envs;
-    boolean useUninstallThenInstallStrategy;
-    String bizAlias;
+    boolean             useUninstallThenInstallStrategy;
+    String              bizAlias;
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationService.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationService.java
@@ -16,15 +16,15 @@
  */
 package com.alipay.sofa.koupleless.arklet.core.ops;
 
-import java.util.List;
-import java.util.Map;
-
 import com.alipay.sofa.ark.api.ClientResponse;
 import com.alipay.sofa.ark.spi.model.Biz;
 import com.alipay.sofa.koupleless.arklet.core.ArkletComponent;
-import com.alipay.sofa.koupleless.arklet.core.command.meta.bizops.ArkBizMeta;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Unified operation service interface, mainly interacts with the sofa-ark container
@@ -35,20 +35,7 @@ import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse;
  */
 public interface UnifiedOperationService extends ArkletComponent {
 
-    /**
-     * install biz
-     *
-     * @param bizUrl biz URL
-     * @return response
-     * @throws java.lang.Throwable error
-     * @param bizName a {@link java.lang.String} object
-     * @param bizVersion a {@link java.lang.String} object
-     * @param args an array of {@link java.lang.String} objects
-     * @param envs a {@link java.util.Map} object
-     */
-    ClientResponse install(String bizName, String bizVersion, String bizUrl, String[] args,
-                           Map<String, String> envs,
-                           boolean useUninstallBeforeInstallStrategy) throws Throwable;
+    ClientResponse install(InstallRequest request) throws Throwable;
 
     /**
      * uninstall biz

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
@@ -76,7 +76,7 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
         String bizName = request.getBizName();
         String bizVersion = request.getBizVersion();
         String bizUrl = request.getBizUrl();
-        String[] args =request.getArgs();
+        String[] args = request.getArgs();
         Map<String, String> envs = request.getEnvs();
         String bizAlias = request.getBizAlias();
 
@@ -96,7 +96,7 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
         bizOperation.setBizName(bizName);
         bizOperation.setBizVersion(bizVersion);
         bizOperation.putParameter(Constants.CONFIG_BIZ_URL, bizUrl);
-        return ArkClient.installOperation(bizOperation, args, envs,bizAlias);
+        return ArkClient.installOperation(bizOperation, args, envs, bizAlias);
     }
 
     private ClientResponse doInstallThenUninstallStrategy(InstallRequest installRequest) throws Throwable {
@@ -119,12 +119,9 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
             String bizName = (String) mainAttributes.get(Constants.ARK_BIZ_NAME);
             String bizVersion = (String) mainAttributes.get(Constants.ARK_BIZ_VERSION);
 
-            InstallRequest installRequest = InstallRequest.builder()
-                    .bizUrl(bizUrl)
-                    .bizName(bizName)
-                    .bizVersion(bizVersion)
-                    .useUninstallThenInstallStrategy(useUninstallThenInstallStrategy)
-                    .build();
+            InstallRequest installRequest = InstallRequest.builder().bizUrl(bizUrl).bizName(bizName)
+                .bizVersion(bizVersion)
+                .useUninstallThenInstallStrategy(useUninstallThenInstallStrategy).build();
             return install(installRequest);
         } catch (Throwable throwable) {
             throwable.printStackTrace();

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/command/handler/InstallBizHandlerTest.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/command/handler/InstallBizHandlerTest.java
@@ -23,6 +23,7 @@ import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.InstallBiz
 import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.InstallBizHandler.Input;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
 import com.alipay.sofa.koupleless.arklet.core.common.exception.CommandValidationException;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.health.custom.model.MockBiz;
 import org.junit.Assert;
 import org.junit.Before;
@@ -59,8 +60,15 @@ public class InstallBizHandlerTest extends BaseHandlerTest {
         input.setBizUrl("testUrl");
         input.setBizName("testBiz1");
 
-        when(handler.getOperationService().install(input.getBizName(), input.getBizVersion(),
-            input.getBizUrl(), input.getArgs(), input.getEnvs(), true)).thenReturn(success);
+        InstallRequest installRequest = InstallRequest.builder()
+                .bizName(input.getBizName())
+                .bizVersion(input.getBizVersion())
+                .bizUrl(input.getBizUrl())
+                .args(input.getArgs())
+                .envs(input.getEnvs())
+                .useUninstallThenInstallStrategy(true)
+                .build();
+        when(handler.getOperationService().install(installRequest)).thenReturn(success);
 
         Output<InstallBizHandler.InstallBizClientResponse> result = handler.handle(input);
 
@@ -76,8 +84,15 @@ public class InstallBizHandlerTest extends BaseHandlerTest {
         input.setBizUrl("testUrl");
         input.setBizName("testBiz1");
 
-        when(handler.getOperationService().install(input.getBizName(), input.getBizVersion(),
-            input.getBizUrl(), input.getArgs(), input.getEnvs(), true)).thenReturn(failed);
+        InstallRequest installRequest = InstallRequest.builder()
+                .bizName(input.getBizName())
+                .bizVersion(input.getBizVersion())
+                .bizUrl(input.getBizUrl())
+                .args(input.getArgs())
+                .envs(input.getEnvs())
+                .useUninstallThenInstallStrategy(true)
+                .build();
+        when(handler.getOperationService().install(installRequest)).thenReturn(failed);
 
         Output<InstallBizHandler.InstallBizClientResponse> result = handler.handle(input);
 

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/command/handler/InstallBizHandlerTest.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/command/handler/InstallBizHandlerTest.java
@@ -60,14 +60,9 @@ public class InstallBizHandlerTest extends BaseHandlerTest {
         input.setBizUrl("testUrl");
         input.setBizName("testBiz1");
 
-        InstallRequest installRequest = InstallRequest.builder()
-                .bizName(input.getBizName())
-                .bizVersion(input.getBizVersion())
-                .bizUrl(input.getBizUrl())
-                .args(input.getArgs())
-                .envs(input.getEnvs())
-                .useUninstallThenInstallStrategy(true)
-                .build();
+        InstallRequest installRequest = InstallRequest.builder().bizName(input.getBizName())
+            .bizVersion(input.getBizVersion()).bizUrl(input.getBizUrl()).args(input.getArgs())
+            .envs(input.getEnvs()).useUninstallThenInstallStrategy(true).build();
         when(handler.getOperationService().install(installRequest)).thenReturn(success);
 
         Output<InstallBizHandler.InstallBizClientResponse> result = handler.handle(input);
@@ -84,14 +79,9 @@ public class InstallBizHandlerTest extends BaseHandlerTest {
         input.setBizUrl("testUrl");
         input.setBizName("testBiz1");
 
-        InstallRequest installRequest = InstallRequest.builder()
-                .bizName(input.getBizName())
-                .bizVersion(input.getBizVersion())
-                .bizUrl(input.getBizUrl())
-                .args(input.getArgs())
-                .envs(input.getEnvs())
-                .useUninstallThenInstallStrategy(true)
-                .build();
+        InstallRequest installRequest = InstallRequest.builder().bizName(input.getBizName())
+            .bizVersion(input.getBizVersion()).bizUrl(input.getBizUrl()).args(input.getArgs())
+            .envs(input.getEnvs()).useUninstallThenInstallStrategy(true).build();
         when(handler.getOperationService().install(installRequest)).thenReturn(failed);
 
         Output<InstallBizHandler.InstallBizClientResponse> result = handler.handle(input);

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
@@ -95,15 +95,9 @@ public class UnifiedOperationServiceImplTests {
             arkClientMockedStatic.when(ArkClient::getBizManagerService)
                 .thenReturn(new MockBizManagerService());
 
-            InstallRequest request = InstallRequest.builder()
-                    .bizUrl("http://example.com/biz.jar")
-                    .bizName("testBiz1")
-                    .bizVersion("bizVersion")
-                    .useUninstallThenInstallStrategy(true)
-                    .bizAlias("bizAlias")
-                    .args(new String[] {})
-                    .envs(new HashMap<>())
-                    .build();
+            InstallRequest request = InstallRequest.builder().bizUrl("http://example.com/biz.jar")
+                .bizName("testBiz1").bizVersion("bizVersion").useUninstallThenInstallStrategy(true)
+                .bizAlias("bizAlias").args(new String[] {}).envs(new HashMap<>()).build();
             ClientResponse response = unifiedOperationService.install(request);
             arkClientMockedStatic
                 .verify(() -> ArkClient.installOperation(Mockito.any(BizOperation.class),

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
@@ -18,10 +18,10 @@ package com.alipay.sofa.koupleless.arklet.core.component;
 
 import com.alipay.sofa.ark.api.ArkClient;
 import com.alipay.sofa.ark.api.ClientResponse;
-import com.alipay.sofa.ark.spi.constant.Constants;
 import com.alipay.sofa.ark.spi.model.BizOperation;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.health.custom.MockBizManagerService;
 import com.alipay.sofa.koupleless.arklet.core.ops.BatchInstallHelper;
 import com.alipay.sofa.koupleless.arklet.core.ops.UnifiedOperationServiceImpl;
@@ -95,8 +95,16 @@ public class UnifiedOperationServiceImplTests {
             arkClientMockedStatic.when(ArkClient::getBizManagerService)
                 .thenReturn(new MockBizManagerService());
 
-            ClientResponse response = unifiedOperationService.install("testBiz1", "bizVersion",
-                "http://example.com/biz.jar", new String[] {}, new HashMap<>(), true);
+            InstallRequest request = InstallRequest.builder()
+                    .bizUrl("http://example.com/biz.jar")
+                    .bizName("testBiz1")
+                    .bizVersion("bizVersion")
+                    .useUninstallThenInstallStrategy(true)
+                    .bizAlias("bizAlias")
+                    .args(new String[] {})
+                    .envs(new HashMap<>())
+                    .build();
+            ClientResponse response = unifiedOperationService.install(request);
             arkClientMockedStatic
                 .verify(() -> ArkClient.installOperation(Mockito.any(BizOperation.class),
                     Mockito.any(String[].class), Mockito.anyMap()));

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/health/custom/model/MockBiz.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/health/custom/model/MockBiz.java
@@ -88,6 +88,11 @@ public class MockBiz implements Biz {
     }
 
     @Override
+    public String getBizAlias() {
+        return "";
+    }
+
+    @Override
     public String getMainClass() {
         return null;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <revision>1.2.3-SNAPSHOT</revision>
-        <sofa.ark.version>2.2.11</sofa.ark.version>
+        <sofa.ark.version>2.2.12-SNAPSHOT</sofa.ark.version>
         <spring.boot.version>2.7.15</spring.boot.version>
         <project.encoding>UTF-8</project.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
arklet 安装时可以指定 bizAlias，需要 sofa-ark 2.2.12 版本

同时修复 https://github.com/koupleless/koupleless/issues/266
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced installation operations with the new `InstallRequest` object, allowing for more streamlined and efficient handling.

- **Refactor**
  - Improved code readability and maintainability by refactoring methods to use the `InstallRequest` object instead of individual parameters.

- **Chores**
  - Updated dependency version to `sofa.ark.version` from `2.2.11` to `2.2.12-SNAPSHOT`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->