### PR TITLE
enable samples test for runtime

### DIFF
--- a/.github/workflows/samples_formatter_and_unit_test.yml
+++ b/.github/workflows/samples_formatter_and_unit_test.yml
@@ -51,8 +51,23 @@ jobs:
           path: 'samples'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Env prepare
+        run: |
+          sudo apt-get update >>/tmp/envprepare.out
+          sudo apt-get install -y expect >>/tmp/envprepare.out
+          docker pull mongo:7.0.2-jammy
+          docker run --name mongodb -d -p 27017:27017 -v /home/runner/work/data:/data/db mongo:7.0.2-jammy
+          docker pull zookeeper:3.9.0
+          docker run -p 2181:2181 -it --name zookeeper --restart always -d zookeeper:3.9.0
+          docker pull apache/rocketmq:4.9.7
+          docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
+          sudo apt-get install redis-server -y
+          sudo systemctl start redis-server
+          docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
+          /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
+
       - name: Test for springboot samples
-        run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true -am -B -U
+        run: mvn clean install -Dmaven.javadoc.skip=true -am -B -U
         working-directory: samples/springboot-samples/
 
   unit-test-for-sofaboot-samples:
@@ -88,8 +103,23 @@ jobs:
           path: 'samples'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Env prepare
+        run: |
+          sudo apt-get update >>/tmp/envprepare.out
+          sudo apt-get install -y expect >>/tmp/envprepare.out
+          docker pull mongo:7.0.2-jammy
+          docker run --name mongodb -d -p 27017:27017 -v /home/runner/work/data:/data/db mongo:7.0.2-jammy
+          docker pull zookeeper:3.9.0
+          docker run -p 2181:2181 -it --name zookeeper --restart always -d zookeeper:3.9.0
+          docker pull apache/rocketmq:4.9.7
+          docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
+          sudo apt-get install redis-server -y
+          sudo systemctl start redis-server
+          docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
+          /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
+
       - name: Test for sofaboot samples
-        run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true -am -B -U
+        run: mvn clean install -Dmaven.javadoc.skip=true -am -B -U
         working-directory: samples/sofaboot-samples
 
   unit-test-for-dubbo-samples:
@@ -125,8 +155,23 @@ jobs:
           path: 'samples'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Env prepare
+        run: |
+          sudo apt-get update >>/tmp/envprepare.out
+          sudo apt-get install -y expect >>/tmp/envprepare.out
+          docker pull mongo:7.0.2-jammy
+          docker run --name mongodb -d -p 27017:27017 -v /home/runner/work/data:/data/db mongo:7.0.2-jammy
+          docker pull zookeeper:3.9.0
+          docker run -p 2181:2181 -it --name zookeeper --restart always -d zookeeper:3.9.0
+          docker pull apache/rocketmq:4.9.7
+          docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
+          sudo apt-get install redis-server -y
+          sudo systemctl start redis-server
+          docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
+          /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
+
       - name: Test for dubbo samples
-        run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true -am -B -U
+        run: mvn clean install -Dmaven.javadoc.skip=true -am -B -U
         working-directory: samples/dubbo-samples
 
   unit-test-for-dubbo32-samples:
@@ -162,8 +207,23 @@ jobs:
           path: 'samples'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Env prepare
+        run: |
+          sudo apt-get update >>/tmp/envprepare.out
+          sudo apt-get install -y expect >>/tmp/envprepare.out
+          docker pull mongo:7.0.2-jammy
+          docker run --name mongodb -d -p 27017:27017 -v /home/runner/work/data:/data/db mongo:7.0.2-jammy
+          docker pull zookeeper:3.9.0
+          docker run -p 2181:2181 -it --name zookeeper --restart always -d zookeeper:3.9.0
+          docker pull apache/rocketmq:4.9.7
+          docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
+          sudo apt-get install redis-server -y
+          sudo systemctl start redis-server
+          docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
+          /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
+
       - name: Test for dubbo32 samples
-        run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true -am -B -U
+        run: mvn clean install -Dmaven.javadoc.skip=true -am -B -U
         working-directory: samples/dubbo32-samples
 
   unit-test-for-springboot3-samples:
@@ -199,6 +259,21 @@ jobs:
           path: 'samples'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Test Env prepare
+        run: |
+          sudo apt-get update >>/tmp/envprepare.out
+          sudo apt-get install -y expect >>/tmp/envprepare.out
+          docker pull mongo:7.0.2-jammy
+          docker run --name mongodb -d -p 27017:27017 -v /home/runner/work/data:/data/db mongo:7.0.2-jammy
+          docker pull zookeeper:3.9.0
+          docker run -p 2181:2181 -it --name zookeeper --restart always -d zookeeper:3.9.0
+          docker pull apache/rocketmq:4.9.7
+          docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
+          sudo apt-get install redis-server -y
+          sudo systemctl start redis-server
+          docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
+          /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
+
       - name: Test for springboot3 samples
-        run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true -am -B -U
+        run: mvn clean install -Dmaven.javadoc.skip=true -am -B -U
         working-directory: samples/springboot3-samples


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a "Test Env prepare" step in the workflow to set up services (MongoDB, Zookeeper, Redis, Apache RocketMQ) before running tests.
  - Modified the test steps to ensure tests and Javadocs are run and generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->