### PR TITLE
fix baseStartupHealthIndicator config

### DIFF
--- a/arklet-springboot-starter/src/main/java/com/alipay/sofa/koupleless/arklet/springboot/starter/health/HealthAutoConfiguration.java
+++ b/arklet-springboot-starter/src/main/java/com/alipay/sofa/koupleless/arklet/springboot/starter/health/HealthAutoConfiguration.java
@@ -56,8 +56,8 @@ public class HealthAutoConfiguration {
     @Bean("baseStartUpHealthIndicator")
     @ConditionalOnClass(name = { "org.springframework.boot.actuate.health.AbstractHealthIndicator" })
     public BaseStartUpHealthIndicator baseStartUpHealthIndicator(Environment masterBizEnvironment) {
-        BaseStartUpHealthIndicator indicator = new BaseStartUpHealthIndicator(
-            Boolean.parseBoolean(masterBizEnvironment.getProperty(WITH_ALL_BIZ_READINESS,"false")));
+        BaseStartUpHealthIndicator indicator = new BaseStartUpHealthIndicator(Boolean
+            .parseBoolean(masterBizEnvironment.getProperty(WITH_ALL_BIZ_READINESS, "false")));
         ArkClient.getEventAdminService().register(indicator);
         return indicator;
     }

--- a/arklet-springboot-starter/src/main/java/com/alipay/sofa/koupleless/arklet/springboot/starter/health/HealthAutoConfiguration.java
+++ b/arklet-springboot-starter/src/main/java/com/alipay/sofa/koupleless/arklet/springboot/starter/health/HealthAutoConfiguration.java
@@ -23,6 +23,7 @@ import com.alipay.sofa.koupleless.common.environment.ConditionalOnMasterBiz;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 import static com.alipay.sofa.koupleless.arklet.springboot.starter.health.BaseStartUpHealthIndicator.WITH_ALL_BIZ_READINESS;
 
@@ -54,9 +55,9 @@ public class HealthAutoConfiguration {
      */
     @Bean("baseStartUpHealthIndicator")
     @ConditionalOnClass(name = { "org.springframework.boot.actuate.health.AbstractHealthIndicator" })
-    public BaseStartUpHealthIndicator baseStartUpHealthIndicator() {
+    public BaseStartUpHealthIndicator baseStartUpHealthIndicator(Environment masterBizEnvironment) {
         BaseStartUpHealthIndicator indicator = new BaseStartUpHealthIndicator(
-            Boolean.parseBoolean(EnvironmentUtils.getProperty(WITH_ALL_BIZ_READINESS, "false")));
+            Boolean.parseBoolean(masterBizEnvironment.getProperty(WITH_ALL_BIZ_READINESS,"false")));
         ArkClient.getEventAdminService().register(indicator);
         return indicator;
     }


### PR DESCRIPTION
修复 koupleless.healthcheck.base.readiness.withAllBizReadiness 的读取方式：修改成从 enviroment 中读取

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the health indicator functionality by enabling it to access environment properties directly for improved flexibility and responsiveness.
	- Updated the method to leverage Spring's dependency injection practices, allowing for dynamic configuration based on different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->