### PR TITLE
add mqtt env config

### DIFF
--- a/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/MqttTunnel.java
+++ b/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/MqttTunnel.java
@@ -52,6 +52,7 @@ public class MqttTunnel implements Tunnel {
     private final static String                                           MQTT_PORT_ATTRIBUTE                 = "koupleless.arklet.mqtt.port";
     private final static String                                           MQTT_USERNAME_ATTRIBUTE             = "koupleless.arklet.mqtt.username";
     private final static String                                           MQTT_PASSWORD_ATTRIBUTE             = "koupleless.arklet.mqtt.password";
+    private final static String                                           MQTT_ENV_KEY_ATTRIBUTE              = "koupleless.arklet.mqtt.env.key";
     private final static String                                           MQTT_CA_FILE_PATH_ATTRIBUTE         = "koupleless.arklet.mqtt.ca_path";
     private final static String                                           MQTT_CLIENT_CRT_FILE_PATH_ATTRIBUTE = "koupleless.arklet.mqtt.client_crt_path";
     private final static String                                           MQTT_CLIENT_KEY_FILE_PATH_ATTRIBUTE = "koupleless.arklet.mqtt.client_key_path";
@@ -70,6 +71,7 @@ public class MqttTunnel implements Tunnel {
     private String                                                        brokerUrl;
     private String                                                        username;
     private String                                                        password;
+    private String                                                        envKey;
     private String                                                        clientPrefix;
     private String                                                        caFilePath;
     private String                                                        clientCrtFilePath;
@@ -91,6 +93,7 @@ public class MqttTunnel implements Tunnel {
             this.brokerUrl = EnvironmentUtils.getProperty(MQTT_BROKER_ATTRIBUTE);
             this.username = EnvironmentUtils.getProperty(MQTT_USERNAME_ATTRIBUTE);
             this.password = EnvironmentUtils.getProperty(MQTT_PASSWORD_ATTRIBUTE);
+            this.envKey = EnvironmentUtils.getProperty(MQTT_ENV_KEY_ATTRIBUTE);
             this.clientPrefix = EnvironmentUtils.getProperty(MQTT_CLIENT_PREFIX_ATTRIBUTE);
             this.caFilePath = EnvironmentUtils.getProperty(MQTT_CA_FILE_PATH_ATTRIBUTE);
             this.clientCrtFilePath = EnvironmentUtils
@@ -102,12 +105,6 @@ public class MqttTunnel implements Tunnel {
                 LOGGER.error("Invalid arklet mqtt port: empty");
                 throw new com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletInitException(
                     "Invalid arklet mqtt port: empty");
-            }
-
-            if (StringUtils.isEmpty(this.brokerUrl)) {
-                LOGGER.error("Invalid arklet mqtt broker: empty");
-                throw new com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletInitException(
-                    "Invalid arklet mqtt broker: empty");
             }
 
             if (StringUtils.isEmpty(this.username)) {
@@ -139,6 +136,11 @@ public class MqttTunnel implements Tunnel {
                 LOGGER.error("Invalid arklet mqtt broker url: empty");
                 throw new ArkletInitException("Invalid arklet mqtt broker url: empty");
             }
+
+            if (StringUtils.isEmpty(this.envKey)) {
+                LOGGER.error("Invalid arklet mqtt envKey: empty");
+                throw new ArkletInitException("Invalid arklet mqtt envKey: empty");
+            }
         }
     }
 
@@ -159,12 +161,12 @@ public class MqttTunnel implements Tunnel {
                 if (!StringUtils.isEmpty(this.caFilePath)) {
                     // init mqtt client with ca and client crt
                     pahoMqttClient = new PahoMqttClient(brokerUrl, port, deviceID, clientPrefix,
-                        username, password, caFilePath, clientCrtFilePath, clientKeyFilePath,
-                        commandService);
+                        this.envKey, username, password, caFilePath, clientCrtFilePath,
+                        clientKeyFilePath, commandService);
                 } else {
                     // init mqtt client with username and password
                     pahoMqttClient = new PahoMqttClient(brokerUrl, port, deviceID, clientPrefix,
-                        username, password, commandService);
+                        this.envKey, username, password, commandService);
                 }
                 pahoMqttClient.open();
             } catch (MqttException e) {

--- a/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/model/Constants.java
+++ b/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/model/Constants.java
@@ -25,11 +25,14 @@ package com.alipay.sofa.koupleless.arklet.tunnel.mqtt.model;
 public class Constants {
 
     /** Constant <code>NETWORK_INFO="system"</code> */
-    public static final String NETWORK_INFO    = "networkInfo";
+    public static final String NETWORK_INFO     = "networkInfo";
 
     /** Constant <code>LOCAL_IP="localIP"</code> */
-    public static final String LOCAL_IP        = "localIP";
+    public static final String LOCAL_IP         = "localIP";
 
     /** Constant <code>LOCAL_HOST_NAME="localHostName"</code> */
-    public static final String LOCAL_HOST_NAME = "localHostName";
+    public static final String LOCAL_HOST_NAME  = "localHostName";
+
+    /** Constant <code>LOCAL_HOST_NAME="localHostName"</code> */
+    public static final String DEFAULT_BASE_ENV = "dev";
 }

--- a/arklet-tunnel-mqtt/src/test/java/com/alipay/sofa/koupleless/arklet/tunnel/paho/PahoClientTest.java
+++ b/arklet-tunnel-mqtt/src/test/java/com/alipay/sofa/koupleless/arklet/tunnel/paho/PahoClientTest.java
@@ -39,7 +39,7 @@ public class PahoClientTest extends BaseTest {
 
         @Override
         public void messageArrived(String topic, MqttMessage mqttMessage) throws Exception {
-            assert topic.equals(String.format("koupleless/%s/base/health", deviceID));
+            assert topic.equals(String.format("koupleless_dev/%s/base/health", deviceID));
         }
     }
 
@@ -49,7 +49,7 @@ public class PahoClientTest extends BaseTest {
         try {
             UUID deviceID = UUID.randomUUID();
             pahoMqttClient = new PahoMqttClient("broker.emqx.io", 1883, deviceID, "koupleless",
-                "emqx", "public", commandService);
+                "test-env-key", "emqx", "public", commandService);
             pahoMqttClient.open();
 
             String broker = "tcp://broker.emqx.io:1883";
@@ -61,9 +61,9 @@ public class PahoClientTest extends BaseTest {
             options.setUserName(username);
             options.setPassword(password.toCharArray());
             client.connect(options);
-            client.publish(String.format("koupleless/%s/health", deviceID),
+            client.publish(String.format("koupleless_dev/%s/health", deviceID),
                 new MqttMessage("{}".getBytes()));
-            client.subscribe(String.format("koupleless/%s/base/health", deviceID),
+            client.subscribe(String.format("koupleless_dev/%s/base/health", deviceID),
                 new HealthMessageListener(deviceID));
         } finally {
             if (pahoMqttClient != null) {
@@ -75,7 +75,7 @@ public class PahoClientTest extends BaseTest {
     @Test
     public void open() throws MqttException {
         PahoMqttClient pahoMqttClient = new PahoMqttClient("broker.emqx.io", 1883,
-            UUID.randomUUID(), "koupleless", "emqx", "public", commandService);
+            UUID.randomUUID(), "koupleless", "test-env-key", "emqx", "public", commandService);
         pahoMqttClient.open();
     }
 }


### PR DESCRIPTION
add env config in mqtt tunnel, support user custom env key, read topic suffix from env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for an environment key in the MQTT tunnel configuration, enhancing the flexibility of MQTT topic generation.
	- Added a new default base environment constant for improved configurability.

- **Bug Fixes**
	- Implemented validation for the environment key to prevent empty values, enhancing robustness.

- **Tests**
	- Updated tests to reflect the new MQTT topic structure and initialization parameters, ensuring accurate test coverage across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->