### PR TITLE
optimize: 显式指定 SerializerFeature.WriteEnumUsingName 避免在使用 fastjson2 时…

### DIFF
--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.alibaba.fastjson.JSONObject;
 
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alipay.sofa.koupleless.arklet.core.api.model.Response;
 import com.alipay.sofa.koupleless.arklet.core.command.CommandService;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
@@ -190,7 +191,7 @@ public class NettyHttpServer {
         private void returnResponse(ChannelHandlerContext ctx, Response response) {
             DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK,
-                Unpooled.copiedBuffer(JSONObject.toJSONString(response), CharsetUtil.UTF_8));
+                Unpooled.copiedBuffer(JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingName), CharsetUtil.UTF_8));
             ChannelFuture future = ctx.writeAndFlush(httpResponse);
             if (future != null) {
                 future.addListener(ChannelFutureListener.CLOSE);


### PR DESCRIPTION
…, 将枚举类序列化为 ordinal 而不是 name

https://github.com/koupleless/arkctl/pull/9#issuecomment-2268237212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the serialization of response objects, enhancing the readability of JSON outputs by converting enum values to their names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->