### PR TITLE
optimize: fastjson toJSONString 显式指定 SerializerFeature 避免在使用 fastjson2 时…

### DIFF
--- a/.github/workflows/samples_formatter_and_unit_test.yml
+++ b/.github/workflows/samples_formatter_and_unit_test.yml
@@ -63,6 +63,7 @@ jobs:
           docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
           sudo apt-get install redis-server -y
           sudo systemctl start redis-server
+          [[ `which docker-compose` ]] || sudo apt-get install -y docker-compose
           docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
           /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
 
@@ -115,6 +116,7 @@ jobs:
           docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
           sudo apt-get install redis-server -y
           sudo systemctl start redis-server
+          [[ `which docker-compose` ]] || sudo apt-get install -y docker-compose
           docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
           /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
 
@@ -167,6 +169,7 @@ jobs:
           docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
           sudo apt-get install redis-server -y
           sudo systemctl start redis-server
+          [[ `which docker-compose` ]] || sudo apt-get install -y docker-compose
           docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
           /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
 
@@ -219,6 +222,7 @@ jobs:
           docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
           sudo apt-get install redis-server -y
           sudo systemctl start redis-server
+          [[ `which docker-compose` ]] || sudo apt-get install -y docker-compose
           docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
           /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
 
@@ -271,6 +275,7 @@ jobs:
           docker run -d -p 9876:9876 -p 10909:10909 -p 10910:10910 -p 10911:10911 -p 10912:10912 -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/start.sh:/home/rocketmq/rocketmq-4.9.7/bin/start.sh -v $(pwd)/samples/springboot-samples/msg/rocketmq/config/broker.conf:/home/rocketmq/rocketmq-4.9.7/bin/broker.conf apache/rocketmq:4.9.7 sh /home/rocketmq/rocketmq-4.9.7/bin/start.sh
           sudo apt-get install redis-server -y
           sudo systemctl start redis-server
+          [[ `which docker-compose` ]] || sudo apt-get install -y docker-compose
           docker-compose  -f samples/springboot-samples/config/apollo/config/docker-compose.yml up -d
           /bin/sh samples/springboot-samples/db/mybatis/config/init_mysql.sh
 

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import com.alibaba.fastjson.JSONObject;
 
+import com.alibaba.fastjson.serializer.SerializerFeature;
 import com.alipay.sofa.koupleless.arklet.core.api.model.Response;
 import com.alipay.sofa.koupleless.arklet.core.command.CommandService;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
@@ -190,7 +191,7 @@ public class NettyHttpServer {
         private void returnResponse(ChannelHandlerContext ctx, Response response) {
             DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK,
-                Unpooled.copiedBuffer(JSONObject.toJSONString(response), CharsetUtil.UTF_8));
+                Unpooled.copiedBuffer(JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingName), CharsetUtil.UTF_8));
             ChannelFuture future = ctx.writeAndFlush(httpResponse);
             if (future != null) {
                 future.addListener(ChannelFutureListener.CLOSE);

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
@@ -191,7 +191,9 @@ public class NettyHttpServer {
         private void returnResponse(ChannelHandlerContext ctx, Response response) {
             DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK,
-                Unpooled.copiedBuffer(JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingName), CharsetUtil.UTF_8));
+                Unpooled.copiedBuffer(
+                    JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingName),
+                    CharsetUtil.UTF_8));
             ChannelFuture future = ctx.writeAndFlush(httpResponse);
             if (future != null) {
                 future.addListener(ChannelFutureListener.CLOSE);

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/api/tunnel/http/netty/NettyHttpServer.java
@@ -192,7 +192,7 @@ public class NettyHttpServer {
             DefaultFullHttpResponse httpResponse = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
                 HttpResponseStatus.OK,
                 Unpooled.copiedBuffer(
-                    JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingName),
+                    JSONObject.toJSONString(response, SerializerFeature.WriteEnumUsingToString),
                     CharsetUtil.UTF_8));
             ChannelFuture future = ctx.writeAndFlush(httpResponse);
             if (future != null) {


### PR DESCRIPTION
optimize: fastjson toJSONString 显式指定 SerializerFeature 避免在使用 fastjson2 时, 将枚举类序列化为 ordinal 而不是 name

https://github.com/koupleless/arkctl/pull/9#issuecomment-2268237212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced JSON serialization for API responses, making enum values more readable by using their names instead of ordinal values.

- **Bug Fixes**
	- Improved clarity in the API's JSON output, aiding clients in understanding the response structure.

- **Chores**
	- Added a check to ensure `docker-compose` is installed before execution in workflow scripts, enhancing robustness and preventing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->