### PR TITLE
feat(模块瘦身): 允许通过指定 maven 参数的方式，指定 maven-source-plugin 版本，避免使用 jar-no-fork 异常

### DIFF
--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageDependencyMojo.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageDependencyMojo.java
@@ -42,10 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.alipay.sofa.koupleless.base.build.plugin.common.FileUtils.createNewDirectory;
@@ -168,7 +165,9 @@ public class KouplelessBasePackageDependencyMojo extends AbstractMojo {
         pom.setLicenses(Collections.singletonList(license));
 
         // 配置 properties
-        pom.setProperties(this.mavenProject.getProperties());
+        Properties properties = this.mavenProject.getProperties();
+        properties.putIfAbsent("maven-source-plugin.version", "3.2.1");
+        pom.setProperties(properties);
 
         // 配置 dependencyManagement
         Set<ArtifactItem> baseModuleArtifacts = getAllBundleArtifact(this.mavenProject);

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
@@ -44,12 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -167,6 +162,11 @@ public class KouplelessBasePackageFacadeMojo extends AbstractMojo {
         license.setName("The Apache License, Version 2.0");
         license.setUrl("http://www.apache.org/licenses/LICENSE-2.0.txt");
         pom.setLicenses(Collections.singletonList(license));
+
+        // 配置 properties
+        Properties properties = this.mavenProject.getProperties();
+        properties.putIfAbsent("maven-source-plugin.version", "3.2.1");
+        pom.setProperties(properties);
 
         // 配置依赖，全都设置成 provided
         Set<ArtifactItem> baseModuleArtifacts = getAllBundleArtifact(this.mavenProject);

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/base-dependency-pom-template.xml
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/base-dependency-pom-template.xml
@@ -11,7 +11,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/base-facade-pom-template.xml
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/base-facade-pom-template.xml
@@ -10,7 +10,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
[【模块瘦身】允许通过指定 maven 参数的方式，指定 maven-source-plugin 版本，避免使用 jar-no-fork 异常](https://github.com/koupleless/runtime/issues/142)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced configurability for Maven project properties, ensuring a default version for the `maven-source-plugin` is set when not defined.
	- Streamlined version management for the `maven-source-plugin` in both the base dependency and facade POM templates, promoting maintainability.

- **Bug Fixes**
	- Improved handling of Maven properties to prevent potential issues with undefined plugin versions during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->