### PR TITLE
fix basePackageFacade

### DIFF
--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.License;
 import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
@@ -53,7 +54,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.alipay.sofa.koupleless.base.build.plugin.KouplelessBasePackageFacadeMojo.JVMFileTypeEnum.JAVA;
-import static com.alipay.sofa.koupleless.base.build.plugin.KouplelessBasePackageFacadeMojo.JVMFileTypeEnum.KOTLIN;
 import static com.alipay.sofa.koupleless.base.build.plugin.common.FileUtils.createNewDirectory;
 import static com.alipay.sofa.koupleless.base.build.plugin.utils.CollectionUtils.nonNull;
 import static com.alipay.sofa.koupleless.base.build.plugin.utils.MavenUtils.getAllBundleArtifact;
@@ -179,6 +179,10 @@ public class KouplelessBasePackageFacadeMojo extends AbstractMojo {
             .map(d -> {
                 Dependency res = MavenUtils.createDependency(d);
                 res.setScope("provided");
+                Exclusion exclusion = new Exclusion();
+                exclusion.setArtifactId("*");
+                exclusion.setGroupId("*");
+                res.setExclusions(Collections.singletonList(exclusion));
                 return res;
             }).collect(Collectors.toList());
         pom.setDependencies(dependencies);

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/KouplelessBasePackageFacadeMojo.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.alipay.sofa.koupleless.base.build.plugin.KouplelessBasePackageFacadeMojo.JVMFileTypeEnum.JAVA;
+import static com.alipay.sofa.koupleless.base.build.plugin.KouplelessBasePackageFacadeMojo.JVMFileTypeEnum.KOTLIN;
 import static com.alipay.sofa.koupleless.base.build.plugin.common.FileUtils.createNewDirectory;
 import static com.alipay.sofa.koupleless.base.build.plugin.utils.CollectionUtils.nonNull;
 import static com.alipay.sofa.koupleless.base.build.plugin.utils.MavenUtils.getAllBundleArtifact;


### PR DESCRIPTION
在打包基座 facade 时，把所有的依赖的间接依赖都排除，避免出现构建时依赖冲突问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved control over dependency resolution by adding exclusion rules for transitive dependencies in the Maven build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->