### PR TITLE
Update BatchInstallHelper.java

### DIFF
--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
@@ -73,7 +73,7 @@ public class BatchInstallHelper {
         List<Map.Entry<Integer, List<String>>> keyInOrder = new ArrayList<>(
             bizUrlsWithPriority.entrySet());
         keyInOrder.sort(Map.Entry.comparingByKey());
-        Map<Integer, List<String>> bizUrlsInOrder = new HashMap<>();
+        Map<Integer, List<String>> bizUrlsInOrder = new LinkedHashMap<>();
         for (Map.Entry<Integer, List<String>> entry : keyInOrder) {
             bizUrlsInOrder.put(entry.getKey(), entry.getValue());
         }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
@@ -26,6 +26,7 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.jar.JarFile;


### PR DESCRIPTION
HashMap是无序，会造成优先级无法按预期顺序部署,改为LinkedHashMap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved the handling of business URLs by ensuring that their order is preserved when accessed, enhancing predictability for users.
  
- **Bug Fixes**
	- Addressed issues related to the iteration order of business URLs, ensuring consistency and reliability in processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->