### PR TITLE
add adapter mapping for spring aop

### DIFF
--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/adapter-mapping.yaml
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/resources/adapter-mapping.yaml
@@ -56,3 +56,11 @@ adapterMappings:
       regexp: ".*(org\\.apache\\.rocketmq:rocketmq-client:4\\.4\\.0).*"
     adapter:
       artifactId: koupleless-adapter-rocketmq-4.4
+  - matcher:
+      regexp: ".*(org\\.springframework:spring-aop:5\\.3\\.27).*"
+    adapter:
+      artifactId: koupleless-adapter-spring-aop-5.3.27
+  - matcher:
+      regexp: ".*(org\\.springframework:spring-aop:6\\.0\\.(8|9)).*"
+    adapter:
+      artifactId: koupleless-adapter-spring-aop-6.0.8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded compatibility of the plugin with additional versions of the Spring AOP framework.
  - Introduced new adapter mappings for Spring AOP versions 5.3.27, 6.0.8, and 6.0.9.

These improvements enhance the plugin's functionality, allowing users to utilize the latest versions of the Spring AOP library seamlessly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->