### PR TITLE
add guard for MultiBizProperties init only once

### DIFF
--- a/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/util/MultiBizPropertiesTest.java
+++ b/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/util/MultiBizPropertiesTest.java
@@ -19,35 +19,41 @@ package com.alipay.sofa.koupleless.common.util;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.*;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static java.lang.Thread.sleep;
+
 public class MultiBizPropertiesTest {
-    private final String key1   = "test-key-1";
-    private final String key2   = "test-key-2";
+    private static final String key1   = "test-key-1";
+    private static final String key2   = "test-key-2";
 
-    private final String key3   = "test-key-3";
+    private static final String key3   = "test-key-3";
 
-    private final String key4   = "test-key-4";
+    private static final String key4   = "test-key-4";
 
-    private final String key5   = "test-key-5";
+    private static final String key5   = "test-key-5";
 
-    private final String value1 = "test-value-1";
-    private final String value2 = "test-value-2";
+    private static final String value1 = "test-value-1";
+    private static final String value2 = "test-value-2";
 
-    private final String value3 = "test-value-3";
+    private static final String value3 = "test-value-3";
 
-    private final String value5 = "test-value-5";
+    private static final String value5 = "test-value-5";
 
-    private ClassLoader  baseClassLoader;
+    private static ClassLoader  baseClassLoader;
 
-    @Before
-    public void before() {
+    @BeforeClass
+    public static void before() throws Exception {
         Thread thread = Thread.currentThread();
         baseClassLoader = thread.getContextClassLoader();
 
@@ -55,7 +61,9 @@ public class MultiBizPropertiesTest {
         System.clearProperty(key2);
         System.clearProperty(key3);
         System.clearProperty(key4);
-        MultiBizProperties.initSystem(TestClassLoader.class.getName());
+        Method method = MultiBizProperties.class.getDeclaredMethod("initSystem", String.class);
+        method.setAccessible(true);
+        method.invoke(null, TestClassLoader.class.getName());
     }
 
     @After
@@ -248,6 +256,13 @@ public class MultiBizPropertiesTest {
         //        biz: get key3=value3
         Assert.assertNotNull(value3);
 
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void initOnlyOnce() {
+        int count = 10;
+        for (int i = 0; i < count; i++)
+            MultiBizProperties.initSystem();
     }
 
     private class TestClassLoader extends URLClassLoader {


### PR DESCRIPTION
fix https://github.com/koupleless/koupleless/issues/269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved initialization process for MultiBizProperties, ensuring it can only be initialized once, enhancing stability and safety.
	- Added a new test to verify that the initialization method can only be called once.

- **Bug Fixes**
	- Restricted access to the initialization method to prevent unintended external calls, reducing potential errors.

- **Tests**
	- Refactored test setup to run once for all tests, improving efficiency.
	- Enhanced test coverage with the addition of a method to validate single initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->