### PR TITLE
fix npe when runtime close

### DIFF
--- a/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/BizRuntimeContext.java
+++ b/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/BizRuntimeContext.java
@@ -183,7 +183,9 @@ public class BizRuntimeContext implements ComponentRegistry {
      */
     public void shutdownContext() {
         try {
-            applicationContext.close();
+            if (null != applicationContext) {
+                applicationContext.close();
+            }
             appClassLoader = null;
         } catch (Throwable throwable) {
             throw new BizRuntimeException(ErrorCodes.SpringContextManager.E100001, throwable);

--- a/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/model/MainApplicationContextHolder.java
+++ b/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/model/MainApplicationContextHolder.java
@@ -73,6 +73,9 @@ public class MainApplicationContextHolder extends ApplicationContextHolder<MainA
     /** {@inheritDoc} */
     @Override
     public void close() {
+        if (applicationContext == null) {
+            return;
+        }
         applicationContext.close();
     }
 }

--- a/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/model/SpringApplicationContextHolder.java
+++ b/koupleless-common/src/main/java/com/alipay/sofa/koupleless/common/model/SpringApplicationContextHolder.java
@@ -66,6 +66,10 @@ public class SpringApplicationContextHolder extends ApplicationContextHolder<App
     /** {@inheritDoc} */
     @Override
     public void close() {
+        if (applicationContext == null) {
+            return;
+        }
+
         AbstractApplicationContext ctx = (AbstractApplicationContext) applicationContext;
         // only need shutdown when root context is active
         if (ctx.isActive()) {

--- a/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/BizRuntimeContextTest.java
+++ b/koupleless-common/src/test/java/com/alipay/sofa/koupleless/common/BizRuntimeContextTest.java
@@ -17,7 +17,9 @@
 package com.alipay.sofa.koupleless.common;
 
 import com.alipay.sofa.ark.spi.model.Biz;
+import com.alipay.sofa.koupleless.common.model.MainApplicationContextHolder;
 import com.alipay.sofa.koupleless.common.model.MockServiceComponent;
+import com.alipay.sofa.koupleless.common.model.SpringApplicationContextHolder;
 import com.alipay.sofa.koupleless.common.service.ServiceState;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -36,5 +38,17 @@ public class BizRuntimeContextTest {
             .interfaceType(Object.class).metaData(new Object()).bean(new Object()).build();
         context.registerService(mockServiceComponent);
         context.unregisterService(mockServiceComponent);
+    }
+
+    @Test
+    public void testClose() {
+        BizRuntimeContext context = new BizRuntimeContext(Mockito.mock(Biz.class));
+        context.shutdownContext();
+
+        context.setApplicationContext(new MainApplicationContextHolder(null));
+        context.shutdownContext();
+
+        context.setApplicationContext(new SpringApplicationContextHolder(null));
+        context.shutdownContext();
     }
 }


### PR DESCRIPTION
修复模块卸载时 bizruntime 的 applicationContext 为 null 时的NPE问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Added null checks in the shutdown process to prevent potential `NullPointerExceptions` in the `BizRuntimeContext`, `MainApplicationContextHolder`, and `SpringApplicationContextHolder` classes.

- **Tests**
	- Introduced a new test method `testClose` to enhance coverage for the shutdown functionality of the `BizRuntimeContext` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->