### PR TITLE
feat:模块复用基座单例bean时，在模块销毁时不销毁基座bean

### DIFF
--- a/koupleless-base-plugin/pom.xml
+++ b/koupleless-base-plugin/pom.xml
@@ -63,6 +63,11 @@
             <version>${sofa.ark.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
     </dependencies>
 

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/ApplicationReactiveWebEnvironment.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/ApplicationReactiveWebEnvironment.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.web.reactive.context.StandardReactiveWebEnvironment;
+import org.springframework.core.env.ConfigurablePropertyResolver;
+import org.springframework.core.env.MutablePropertySources;
+
+/**
+ * copy from {@link org.springframework.boot.web.reactive.context.ApplicationReactiveWebEnvironment}
+ * due to not public class
+ * {@link StandardReactiveWebEnvironment} for typical use in a typical
+ * {@link SpringApplication}.
+ *
+ * @author Phillip Webb
+ */
+class ApplicationReactiveWebEnvironment extends StandardReactiveWebEnvironment {
+
+    @Override
+    protected String doGetActiveProfilesProperty() {
+        return null;
+    }
+
+    @Override
+    protected String doGetDefaultProfilesProperty() {
+        return null;
+    }
+
+    @Override
+    protected ConfigurablePropertyResolver createPropertyResolver(MutablePropertySources propertySources) {
+        return ConfigurationPropertySources.createPropertyResolver(propertySources);
+    }
+
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/ApplicationServletEnvironment.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/ApplicationServletEnvironment.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.core.env.ConfigurablePropertyResolver;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.web.context.support.StandardServletEnvironment;
+
+/**
+ * copy from {@link org.springframework.boot.web.reactive.context.ApplicationServletEnvironment}
+ * due to not public class
+ * {@link StandardServletEnvironment} for typical use in a typical
+ * {@link SpringApplication}.
+ *
+ * @author Phillip Webb
+ */
+class ApplicationServletEnvironment extends StandardServletEnvironment {
+
+    @Override
+    protected String doGetActiveProfilesProperty() {
+        return null;
+    }
+
+    @Override
+    protected String doGetDefaultProfilesProperty() {
+        return null;
+    }
+
+    @Override
+    protected ConfigurablePropertyResolver createPropertyResolver(MutablePropertySources propertySources) {
+        return ConfigurationPropertySources.createPropertyResolver(propertySources);
+    }
+
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizAnnotationConfigReactiveWebServerApplicationContext.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizAnnotationConfigReactiveWebServerApplicationContext.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.ApplicationContextFactory;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebServerApplicationContext;
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * 目的是自定义 beanFactory 的销毁行为
+ *
+ * @author duanzhiqiang
+ * @version BizAnnotationConfigReactiveWebServerApplicationContext.java, v 0.1 2024年11月08日 16:23 duanzhiqiang
+ */
+public class BizAnnotationConfigReactiveWebServerApplicationContext extends
+        AnnotationConfigReactiveWebServerApplicationContext {
+    /**
+     * 构造器
+     *
+     * @param beanFactory 指定的beanFactory
+     */
+    public BizAnnotationConfigReactiveWebServerApplicationContext(DefaultListableBeanFactory beanFactory) {
+        super(beanFactory);
+    }
+
+    /**
+     * 替换上下文创建行为利用 spring boot factories 扩展 并在默认的优先级前
+     * {@link ApplicationContextFactory} registered in {@code spring.factories} to support
+     * {@link AnnotationConfigServletWebServerApplicationContext}.
+     */
+    static class Factory implements ApplicationContextFactory, Ordered {
+
+        @Override
+        public Class<? extends ConfigurableEnvironment> getEnvironmentType(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.REACTIVE) ? null
+                    : ApplicationReactiveWebEnvironment.class;
+        }
+
+        @Override
+        public ConfigurableEnvironment createEnvironment(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.REACTIVE) ? null
+                    : new ApplicationReactiveWebEnvironment();
+        }
+
+        @Override
+        public ConfigurableApplicationContext create(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.REACTIVE) ? null : createContext();
+        }
+
+        /**
+         * 创建上下文
+         *
+         * @return 上下文
+         */
+        private ConfigurableApplicationContext createContext() {
+            //自定义BeanFactory的销毁
+            DefaultListableBeanFactory beanFactory = new BizDefaultListableBeanFactory();
+            return new BizAnnotationConfigReactiveWebServerApplicationContext(beanFactory);
+        }
+
+        @Override
+        public int getOrder() {
+            return Ordered.HIGHEST_PRECEDENCE;
+        }
+    }
+
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizAnnotationConfigServletWebServerApplicationContext.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizAnnotationConfigServletWebServerApplicationContext.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.boot.ApplicationContextFactory;
+import org.springframework.boot.WebApplicationType;
+
+import org.springframework.boot.web.servlet.context.AnnotationConfigServletWebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * 目的是自定义 beanFactory 的销毁行为
+ *
+ * @author duanzhiqiang
+ * @version BizAnnotationConfigServletWebServerApplicationContext.java, v 0.1 2024年11月08日 16:23 duanzhiqiang
+ */
+public class BizAnnotationConfigServletWebServerApplicationContext extends
+                                                                   AnnotationConfigServletWebServerApplicationContext {
+    /**
+     * 构造器
+     *
+     * @param beanFactory 指定的beanFactory
+     */
+    public BizAnnotationConfigServletWebServerApplicationContext(DefaultListableBeanFactory beanFactory) {
+        super(beanFactory);
+    }
+
+    @Override
+    public Object getBean(String name) throws BeansException {
+        return super.getBean(name);
+    }
+
+    @Override
+    public <T> T getBean(Class<T> requiredType, Object... args) throws BeansException {
+        return super.getBean(requiredType, args);
+    }
+
+    /**
+     * 替换上下文创建行为利用 spring boot factories 扩展 并在默认的优先级前
+     * {@link ApplicationContextFactory} registered in {@code spring.factories} to support
+     * {@link AnnotationConfigServletWebServerApplicationContext}.
+     */
+    static class Factory implements ApplicationContextFactory, Ordered {
+
+        @Override
+        public Class<? extends ConfigurableEnvironment> getEnvironmentType(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.SERVLET) ? null
+                : ApplicationServletEnvironment.class;
+        }
+
+        @Override
+        public ConfigurableEnvironment createEnvironment(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.SERVLET) ? null
+                : new ApplicationServletEnvironment();
+        }
+
+        @Override
+        public ConfigurableApplicationContext create(WebApplicationType webApplicationType) {
+            return (webApplicationType != WebApplicationType.SERVLET) ? null : createContext();
+        }
+
+        /**
+         * 创建上下文
+         *
+         * @return 上下文
+         */
+        private ConfigurableApplicationContext createContext() {
+            //自定义BeanFactory的销毁
+            DefaultListableBeanFactory beanFactory = new BizDefaultListableBeanFactory();
+            return new BizAnnotationConfigServletWebServerApplicationContext(beanFactory);
+        }
+
+        @Override
+        public int getOrder() {
+            return HIGHEST_PRECEDENCE;
+        }
+    }
+
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizDefaultListableBeanFactory.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/BizDefaultListableBeanFactory.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.lang.Nullable;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 重写销毁方法 当bean是 来着基座的bean 注册到biz时 不进行销毁
+ *
+ * @author duanzhiqiang
+ * @version BizDefaultListableBeanFactory.java, v 0.1 2024年11月08日 16:45 duanzhiqiang
+ */
+public class BizDefaultListableBeanFactory extends DefaultListableBeanFactory {
+
+    /**
+     * 是否是基座beanFactory
+     */
+    private final boolean isBaseBeanFactory;
+
+    /**
+     * 在创建时 额外判断是否是基座bean
+     */
+    public BizDefaultListableBeanFactory() {
+        super();
+        this.isBaseBeanFactory = !isOnBiz();
+    }
+
+    /**
+     * 当前正在销毁的单例bean
+     */
+    private static final ThreadLocal<Object> CUR_DESTROY_SINGLE_BEAN_HOLDER = new ThreadLocal<>();
+
+    /**
+     * 基座bean复用bean集合
+     */
+    private static final Set<Object>         BASE_RESUE_BEAN_SET            = Collections
+        .newSetFromMap(new ConcurrentHashMap<>());
+
+    private static final String              BIZ_CLASSLOADER                = "com.alipay.sofa.ark.container.service.classloader.BizClassLoader";
+
+    /**
+     * 在子模块获取 base 的bean 记录这个bean 引用
+     *
+     * @param name          the name of the bean to retrieve
+     * @param requiredType  the required type of the bean to retrieve
+     * @param args          arguments to use when creating a bean instance using explicit arguments
+     *                      (only applied when creating a new instance as opposed to retrieving an existing one)
+     * @param typeCheckOnly whether the instance is obtained for a type check,
+     *                      not for actual use
+     * @param <T>           the required type of the bean to retrieve
+     * @return bean
+     * @throws BeansException 异常
+     */
+    @Override
+    protected <T> T doGetBean(String name, Class<T> requiredType, Object[] args,
+                              boolean typeCheckOnly) throws BeansException {
+
+        T bean = super.doGetBean(name, requiredType, args, typeCheckOnly);
+        try {
+            //复用基座的bean时 记录下复用的基座bean
+            if (isSingleton(name) && isOnBiz() && isBaseBeanFactory) {
+                BASE_RESUE_BEAN_SET.add(bean);
+            }
+        } catch (Exception e) {
+            logger.error("记录复用基座bean异常", e);
+        }
+        return bean;
+    }
+
+    /**
+     * 在模块卸载时 getBeanFactory().destroySingletons();
+     * 最终会调用 下面的方法
+     * Destroy the given bean. Must destroy beans that depend on the given
+     * bean before the bean itself. Should not throw any exceptions.
+     *
+     * @param beanName the name of the bean
+     * @param bean     the bean instance to destroy
+     */
+    protected void destroyBean(String beanName, @Nullable DisposableBean bean) {
+        if (!isBaseBeanFactory && isBaseBean()) {
+            //传为null时不进行销毁
+            super.destroyBean(beanName, null);
+            return;
+        }
+        super.destroyBean(beanName, bean);
+
+    }
+
+    /**
+     * 单例bean销毁是 在线程上下文记录下当前销毁的bean 只在子模块中生效
+     *
+     * @param beanName the name of the bean
+     */
+    @Override
+    public void destroySingleton(String beanName) {
+        if (!isBaseBeanFactory) {
+            try {
+                Object bean = getBean(beanName);
+                CUR_DESTROY_SINGLE_BEAN_HOLDER.set(bean);
+                super.destroySingleton(beanName);
+            } finally {
+                CUR_DESTROY_SINGLE_BEAN_HOLDER.remove();
+            }
+        } else {
+            super.destroySingleton(beanName);
+        }
+    }
+
+    /**
+     * 判断是否是基座的bean
+     * 基于记录了那些跨模块的bean
+     *
+     * @return true 是基座的bean
+     */
+    private boolean isBaseBean() {
+        Object curDestroySingleBean = CUR_DESTROY_SINGLE_BEAN_HOLDER.get();
+        if (curDestroySingleBean != null) {
+            return BASE_RESUE_BEAN_SET.contains(curDestroySingleBean);
+        }
+        return false;
+    }
+
+    /**
+     * 判断是否在biz中 而不是基座中
+     *
+     * @return true 在biz中
+     */
+    private boolean isOnBiz() {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        return contextClassLoader == null
+               || BIZ_CLASSLOADER.equals(contextClassLoader.getClass().getName());
+    }
+
+    /**
+     * Getter method for property <tt>isBase</tt>.
+     *
+     * @return property value of isBase
+     */
+    public boolean isBaseBeanFactory() {
+        return isBaseBeanFactory;
+    }
+
+}

--- a/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/DefaultApplicationContextFactory.java
+++ b/koupleless-base-plugin/src/main/java/com/alipay/sofa/koupleless/plugin/context/DefaultApplicationContextFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.plugin.context;
+
+import org.springframework.boot.ApplicationContextFactory;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.Ordered;
+
+/**
+ * WebApplicationType.NONE 自定义上下文
+ *
+ * @author duanzhiqiang
+ * @version DefaultApplicationContextFactory.java, v 0.1 2024年11月12日 17:55 duanzhiqiang
+ */
+public class DefaultApplicationContextFactory implements ApplicationContextFactory, Ordered {
+    @Override
+    public ConfigurableApplicationContext create(WebApplicationType webApplicationType) {
+        return (webApplicationType != WebApplicationType.NONE) ? null
+                : new AnnotationConfigApplicationContext(new BizDefaultListableBeanFactory());
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+}

--- a/koupleless-base-plugin/src/main/resources/META-INF/spring.factories
+++ b/koupleless-base-plugin/src/main/resources/META-INF/spring.factories
@@ -13,3 +13,9 @@ org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
 
 org.springframework.context.ApplicationContextInitializer=\
   com.alipay.sofa.koupleless.plugin.spring.BizApplicationContextInitializer
+
+
+org.springframework.boot.ApplicationContextFactory=\
+com.alipay.sofa.koupleless.plugin.context.BizAnnotationConfigReactiveWebServerApplicationContext.Factory,\
+com.alipay.sofa.koupleless.plugin.context.BizAnnotationConfigServletWebServerApplicationContext.Factory, \
+com.alipay.sofa.koupleless.plugin.context.DefaultApplicationContextFactory


### PR DESCRIPTION
1、基于Spring boot启动预留的ApplicationContextFactory，自定义DefaultListableBeanFactory修改销毁流程