### PR TITLE
Feat: add batch install biz handler

### DIFF
--- a/arklet-core/pom.xml
+++ b/arklet-core/pom.xml
@@ -16,6 +16,7 @@
         <dependency>
             <groupId>com.alipay.sofa</groupId>
             <artifactId>sofa-ark-api</artifactId>
+            <version>${sofa.ark.version}</version>
         </dependency>
         <dependency>
             <groupId>com.alipay.sofa.koupleless</groupId>

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/CommandServiceImpl.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/CommandServiceImpl.java
@@ -26,6 +26,7 @@ import com.alibaba.fastjson.JSONObject;
 import com.alipay.sofa.ark.common.util.BizIdentityUtils;
 import com.alipay.sofa.common.utils.StringUtil;
 import com.alipay.sofa.koupleless.arklet.core.api.model.ResponseCode;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.BatchInstallBizHandler;
 import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.HelpHandler;
 import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.InstallBizHandler;
 import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.QueryAllBizHandler;
@@ -98,6 +99,7 @@ public class CommandServiceImpl implements CommandService {
         registerCommandHandler(new SwitchBizHandler());
         registerCommandHandler(new HealthHandler());
         registerCommandHandler(new QueryBizOpsHandler());
+        registerCommandHandler(new BatchInstallBizHandler());
     }
 
     /** {@inheritDoc} */

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/BuiltinCommand.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/BuiltinCommand.java
@@ -31,6 +31,8 @@ public enum BuiltinCommand implements Command {
 
                                                INSTALL_BIZ("installBiz", "install one ark biz"),
 
+    BATCH_INSTALL_BIZ("batchInstallBiz", "install one ark biz"),
+
                                                UNINSTALL_BIZ("uninstallBiz",
                                                              "uninstall one ark biz"),
 

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/BuiltinCommand.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/BuiltinCommand.java
@@ -31,7 +31,8 @@ public enum BuiltinCommand implements Command {
 
                                                INSTALL_BIZ("installBiz", "install one ark biz"),
 
-    BATCH_INSTALL_BIZ("batchInstallBiz", "install one ark biz"),
+                                               BATCH_INSTALL_BIZ("batchInstallBiz",
+                                                                 "install one ark biz"),
 
                                                UNINSTALL_BIZ("uninstallBiz",
                                                              "uninstall one ark biz"),

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.command.builtin.handler;
 
@@ -30,13 +42,15 @@ import static com.alipay.sofa.koupleless.arklet.core.command.builtin.BuiltinComm
  * @author lianglipeng.llp@alibaba-inc.com
  * @version $Id: BatchInstallBizHandler.java, v 0.1 2024年12月18日 15:04 立蓬 Exp $
  */
-public class BatchInstallBizHandler extends AbstractCommandHandler<BatchInstallInput, BatchInstallResponse> implements ArkBizOps {
+public class BatchInstallBizHandler extends
+                                    AbstractCommandHandler<BatchInstallInput, BatchInstallResponse>
+                                    implements ArkBizOps {
 
     @Override
     public void validate(BatchInstallInput batchInstallInput) throws CommandValidationException {
         notNull(batchInstallInput.getBizList(), "bizList is null");
 
-        for(Input bizInput: batchInstallInput.bizList){
+        for (Input bizInput : batchInstallInput.bizList) {
             bizInput.setAsync(false);
             InstallBizHandler.validateInput(bizInput);
         }
@@ -48,9 +62,8 @@ public class BatchInstallBizHandler extends AbstractCommandHandler<BatchInstallI
         long startSpace = metaSpaceMXBean.getUsage().getUsed();
         try {
             BatchInstallResponse response = convertClientResponse(
-                    getOperationService().batchInstall(convertBatchInstallRequest(batchInstallInput)));
-            response
-                    .setElapsedSpace(metaSpaceMXBean.getUsage().getUsed() - startSpace);
+                getOperationService().batchInstall(convertBatchInstallRequest(batchInstallInput)));
+            response.setElapsedSpace(metaSpaceMXBean.getUsage().getUsed() - startSpace);
             if (ResponseCode.SUCCESS.equals(response.getCode())) {
                 return Output.ofSuccess(response);
             } else {
@@ -69,17 +82,14 @@ public class BatchInstallBizHandler extends AbstractCommandHandler<BatchInstallI
     private BatchInstallRequest convertBatchInstallRequest(BatchInstallInput input) {
         ArrayList<InstallRequest> installRequestList = new ArrayList<>();
 
-        for(Input bizInput: input.getBizList()){
-            installRequestList.add(InstallRequest.builder()
-                    .bizName(bizInput.getBizName())
-                    .bizVersion(bizInput.getBizVersion())
-                    .bizUrl(bizInput.getBizUrl())
-                    .args(bizInput.getArgs())
-                    .envs(bizInput.getEnvs())
-                    .installStrategy(bizInput.getInstallStrategy())
-                    .build());
+        for (Input bizInput : input.getBizList()) {
+            installRequestList.add(InstallRequest.builder().bizName(bizInput.getBizName())
+                .bizVersion(bizInput.getBizVersion()).bizUrl(bizInput.getBizUrl())
+                .args(bizInput.getArgs()).envs(bizInput.getEnvs())
+                .installStrategy(bizInput.getInstallStrategy()).build());
         }
-        return BatchInstallRequest.builder().installRequests(installRequestList.toArray(new InstallRequest[0])).build();
+        return BatchInstallRequest.builder()
+            .installRequests(installRequestList.toArray(new InstallRequest[0])).build();
     }
 
     private BatchInstallResponse convertClientResponse(com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse res) {
@@ -98,7 +108,8 @@ public class BatchInstallBizHandler extends AbstractCommandHandler<BatchInstallI
 
     @Getter
     @Setter
-    public static class BatchInstallResponse extends com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse {
+    public static class BatchInstallResponse extends
+                                             com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse {
         private long elapsedSpace;
     }
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
@@ -22,8 +22,8 @@ import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.BatchInsta
 import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.InstallBizHandler.Input;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.AbstractCommandHandler;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.Command;
-import com.alipay.sofa.koupleless.arklet.core.command.meta.InputMeta;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.bizops.ArkBizMeta;
 import com.alipay.sofa.koupleless.arklet.core.command.meta.bizops.ArkBizOps;
 import com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletRuntimeException;
 import com.alipay.sofa.koupleless.arklet.core.common.exception.CommandValidationException;
@@ -102,7 +102,7 @@ public class BatchInstallBizHandler extends
 
     @Getter
     @Setter
-    public static class BatchInstallInput extends InputMeta {
+    public static class BatchInstallInput extends ArkBizMeta {
         private Input[] bizList;
     }
 

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/BatchInstallBizHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.command.builtin.handler;
+
+import com.alipay.sofa.ark.api.ResponseCode;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.BatchInstallBizHandler.BatchInstallInput;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.BatchInstallBizHandler.BatchInstallResponse;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.handler.InstallBizHandler.Input;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.AbstractCommandHandler;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.Command;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.InputMeta;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.bizops.ArkBizOps;
+import com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletRuntimeException;
+import com.alipay.sofa.koupleless.arklet.core.common.exception.CommandValidationException;
+import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.util.ResourceUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.management.MemoryPoolMXBean;
+import java.util.ArrayList;
+
+import static com.alipay.sofa.koupleless.arklet.core.command.builtin.BuiltinCommand.BATCH_INSTALL_BIZ;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: BatchInstallBizHandler.java, v 0.1 2024年12月18日 15:04 立蓬 Exp $
+ */
+public class BatchInstallBizHandler extends AbstractCommandHandler<BatchInstallInput, BatchInstallResponse> implements ArkBizOps {
+
+    @Override
+    public void validate(BatchInstallInput batchInstallInput) throws CommandValidationException {
+        notNull(batchInstallInput.getBizList(), "bizList is null");
+
+        for(Input bizInput: batchInstallInput.bizList){
+            bizInput.setAsync(false);
+            InstallBizHandler.validateInput(bizInput);
+        }
+    }
+
+    @Override
+    public Output<BatchInstallResponse> handle(BatchInstallInput batchInstallInput) {
+        MemoryPoolMXBean metaSpaceMXBean = ResourceUtils.getMetaSpaceMXBean();
+        long startSpace = metaSpaceMXBean.getUsage().getUsed();
+        try {
+            BatchInstallResponse response = convertClientResponse(
+                    getOperationService().batchInstall(convertBatchInstallRequest(batchInstallInput)));
+            response
+                    .setElapsedSpace(metaSpaceMXBean.getUsage().getUsed() - startSpace);
+            if (ResponseCode.SUCCESS.equals(response.getCode())) {
+                return Output.ofSuccess(response);
+            } else {
+                return Output.ofFailed(response, "install biz not success!");
+            }
+        } catch (Throwable e) {
+            throw new ArkletRuntimeException(e);
+        }
+    }
+
+    @Override
+    public Command command() {
+        return BATCH_INSTALL_BIZ;
+    }
+
+    private BatchInstallRequest convertBatchInstallRequest(BatchInstallInput input) {
+        ArrayList<InstallRequest> installRequestList = new ArrayList<>();
+
+        for(Input bizInput: input.getBizList()){
+            installRequestList.add(InstallRequest.builder()
+                    .bizName(bizInput.getBizName())
+                    .bizVersion(bizInput.getBizVersion())
+                    .bizUrl(bizInput.getBizUrl())
+                    .args(bizInput.getArgs())
+                    .envs(bizInput.getEnvs())
+                    .installStrategy(bizInput.getInstallStrategy())
+                    .build());
+        }
+        return BatchInstallRequest.builder().installRequests(installRequestList.toArray(new InstallRequest[0])).build();
+    }
+
+    private BatchInstallResponse convertClientResponse(com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse res) {
+        BatchInstallResponse response = new BatchInstallResponse();
+        response.setBizUrlToResponse(res.getBizUrlToResponse());
+        response.setCode(res.getCode());
+        response.setMessage(res.getMessage());
+        return response;
+    }
+
+    @Getter
+    @Setter
+    public static class BatchInstallInput extends InputMeta {
+        private Input[] bizList;
+    }
+
+    @Getter
+    @Setter
+    public static class BatchInstallResponse extends com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse {
+        private long elapsedSpace;
+    }
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/command/builtin/handler/InstallBizHandler.java
@@ -106,12 +106,12 @@ public class InstallBizHandler extends
 
     public static void validateInput(Input input) throws CommandValidationException {
         isTrue(!input.isAsync() || !StringUtils.isEmpty(input.getRequestId()),
-                "requestId should not be blank when async is true");
+            "requestId should not be blank when async is true");
         notBlank(input.getBizUrl(), "bizUrl should not be blank");
 
         if (StringUtils.isEmpty(input.getBizName()) || StringUtils.isEmpty(input.getBizVersion())) {
             LOGGER.warn(
-                    "biz name and version should not be empty, or it will reduce the performance.");
+                "biz name and version should not be empty, or it will reduce the performance.");
         }
 
         if (StringUtils.isEmpty(input.getBizName()) && StringUtils.isEmpty(input.getBizVersion())) {
@@ -120,16 +120,16 @@ public class InstallBizHandler extends
                 refreshBizInfoFromJar(input);
             } catch (IOException e) {
                 throw new CommandValidationException(
-                        String.format("refresh biz info from jar failed: %s", e.getMessage()));
+                    String.format("refresh biz info from jar failed: %s", e.getMessage()));
             }
         } else if (!StringUtils.isEmpty(input.getBizName())
-                && !StringUtils.isEmpty(input.getBizVersion())) {
+                   && !StringUtils.isEmpty(input.getBizVersion())) {
             // if bizName and bizVersion is not blank, it means that we should install the biz with the given bizName and bizVersion.
             // do nothing.
         } else {
             // if bizName or bizVersion is blank, it is invalid, throw exception.
             throw new CommandValidationException(
-                    "bizName and bizVersion should be both blank or both not blank.");
+                "bizName and bizVersion should be both blank or both not blank.");
         }
     }
 

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/BatchInstallRequest.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/BatchInstallRequest.java
@@ -37,12 +37,12 @@ public class BatchInstallRequest {
     /**
      * 本地文件系统目录。
      */
-    private String bizDirAbsolutePath;
+    private String           bizDirAbsolutePath;
     /**
      * 静态合并部署，默认没有老版本模块，可以直接使用普通安装策略。
      */
     @Builder.Default
-    private String installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
+    private String           installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
 
     /**
      * 模块批量发布请求。

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/BatchInstallRequest.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/common/model/BatchInstallRequest.java
@@ -43,4 +43,9 @@ public class BatchInstallRequest {
      */
     @Builder.Default
     private String installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
+
+    /**
+     * 模块批量发布请求。
+     */
+    private InstallRequest[] installRequests = new InstallRequest[0];
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/BatchInstallHelper.java
@@ -47,7 +47,7 @@ public class BatchInstallHelper {
      * @return a {@link java.util.List} object
      */
     @SneakyThrows
-    public Map<Integer, List<String>> getBizUrlsFromLocalFileSystem(String absoluteBizDirPath) {
+    public static Map<Integer, List<String>> getBizUrlsFromLocalFileSystem(String absoluteBizDirPath) {
         Map<Integer, List<String>> bizUrlsWithPriority = new HashMap<>();
         Files.walkFileTree(new File(absoluteBizDirPath).toPath(), new SimpleFileVisitor<Path>() {
             @Override
@@ -89,7 +89,7 @@ public class BatchInstallHelper {
      * @return 主属性。
      */
     @SneakyThrows
-    public Map<String, Object> getMainAttributes(String bizUrl) {
+    public static Map<String, Object> getMainAttributes(String bizUrl) {
         try (JarFile jarFile = new JarFile(bizUrl)) {
             Manifest manifest = jarFile.getManifest();
             Preconditions.checkState(manifest != null, "Manifest file not found in the JAR.");

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
@@ -21,7 +21,11 @@ import com.alipay.sofa.ark.api.ClientResponse;
 import com.alipay.sofa.ark.api.ResponseCode;
 import com.alipay.sofa.ark.spi.constant.Constants;
 import com.alipay.sofa.ark.spi.model.Biz;
+import com.alipay.sofa.common.utils.StringUtil;
 import com.alipay.sofa.koupleless.arklet.core.command.executor.ExecutorServiceManager;
+import com.alipay.sofa.koupleless.arklet.core.ops.strategy.BatchInstallBizInDirAbsolutePathStrategy;
+import com.alipay.sofa.koupleless.arklet.core.ops.strategy.BatchInstallBizInRequestStrategy;
+import com.alipay.sofa.koupleless.arklet.core.ops.strategy.BatchInstallStrategy;
 import com.alipay.sofa.koupleless.common.log.ArkletLoggerFactory;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
 import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallResponse;
@@ -35,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -47,8 +52,9 @@ import java.util.concurrent.ThreadPoolExecutor;
  */
 @Singleton
 public class UnifiedOperationServiceImpl implements UnifiedOperationService {
+    private final BatchInstallStrategy batchInstallBizInDirAbsolutePathStrategy = new BatchInstallBizInDirAbsolutePathStrategy();
 
-    private BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
+    private final BatchInstallStrategy batchInstallBizInRequestStrategy = new BatchInstallBizInRequestStrategy();
 
     /** {@inheritDoc} */
     @Override
@@ -72,20 +78,12 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
     /**
      * <p>safeBatchInstall.</p>
      *
-     * @param bizAbsolutePath a {@link java.lang.String} object
+     * @param bizRequest a {@link InstallRequest} object
      * @return a {@link com.alipay.sofa.ark.api.ClientResponse} object
      */
-    public ClientResponse safeBatchInstall(String bizAbsolutePath, String installStrategy) {
+    public ClientResponse safeBatchInstall(InstallRequest bizRequest) {
         try {
-            String bizUrl = OSUtils.getLocalFileProtocolPrefix() + bizAbsolutePath;
-            Map<String, Object> mainAttributes = batchInstallHelper
-                .getMainAttributes(bizAbsolutePath);
-            String bizName = (String) mainAttributes.get(Constants.ARK_BIZ_NAME);
-            String bizVersion = (String) mainAttributes.get(Constants.ARK_BIZ_VERSION);
-
-            InstallRequest installRequest = InstallRequest.builder().bizUrl(bizUrl).bizName(bizName)
-                .bizVersion(bizVersion).installStrategy(installStrategy).build();
-            return install(installRequest);
+            return install(bizRequest);
         } catch (Throwable throwable) {
             throwable.printStackTrace();
             return new ClientResponse().setCode(ResponseCode.FAILED)
@@ -103,18 +101,19 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
     @Override
     public BatchInstallResponse batchInstall(BatchInstallRequest request) throws Throwable {
         long startTimestamp = System.currentTimeMillis();
-        Map<Integer, List<String>> bizUrls = batchInstallHelper
-            .getBizUrlsFromLocalFileSystem(request.getBizDirAbsolutePath());
-        ThreadPoolExecutor executorService = ExecutorServiceManager.getArkBizOpsExecutor();
 
+        BatchInstallStrategy batchInstallStrategy = getBatchInstallStrategy(request);
+        Map<Integer,List<InstallRequest>> installRequestsWithOrder = batchInstallStrategy.convertToInstallInput(request);
+
+        ThreadPoolExecutor executorService = ExecutorServiceManager.getArkBizOpsExecutor();
         Map<String, ClientResponse> bizUrlToInstallResult = new HashMap<>();
         boolean hasFailed = false;
-        for (Map.Entry<Integer, List<String>> entry : bizUrls.entrySet()) {
-            List<String> bizUrlsInSameOrder = entry.getValue();
+        for (Entry<Integer,List<InstallRequest>> entry : installRequestsWithOrder.entrySet()) {
+            List<InstallRequest> bizRequestInSameOrder = entry.getValue();
             List<CompletableFuture<ClientResponse>> futures = new ArrayList<>();
-            for (String bizUrl : bizUrlsInSameOrder) {
+            for (InstallRequest bizRequest : bizRequestInSameOrder) {
                 futures.add(CompletableFuture.supplyAsync(
-                    () -> safeBatchInstall(bizUrl, request.getInstallStrategy()), executorService));
+                    () -> safeBatchInstall(bizRequest), executorService));
             }
 
             // wait for all install futures done
@@ -122,8 +121,8 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
             int counter = 0;
             for (CompletableFuture<ClientResponse> future : futures) {
                 ClientResponse clientResponse = future.get();
-                String bizUrl = bizUrlsInSameOrder.get(counter);
-                bizUrlToInstallResult.put(bizUrl, clientResponse);
+                InstallRequest bizRequest = bizRequestInSameOrder.get(counter);
+                bizUrlToInstallResult.put(bizRequest.getBizUrl(), clientResponse);
                 hasFailed = hasFailed || clientResponse.getCode() != ResponseCode.SUCCESS;
                 counter++;
             }
@@ -137,6 +136,13 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
             .code(hasFailed ? ResponseCode.FAILED : ResponseCode.SUCCESS)
             .message(hasFailed ? "batch install failed" : "batch install success")
             .bizUrlToResponse(bizUrlToInstallResult).build();
+    }
+
+    private BatchInstallStrategy getBatchInstallStrategy(BatchInstallRequest request) {
+        if(StringUtil.isNotEmpty(request.getBizDirAbsolutePath())){
+            return batchInstallBizInRequestStrategy;
+        }
+        return batchInstallBizInRequestStrategy;
     }
 
     /** {@inheritDoc} */

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
@@ -141,7 +141,7 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
 
     private BatchInstallStrategy getBatchInstallStrategy(BatchInstallRequest request) {
         if (StringUtil.isNotEmpty(request.getBizDirAbsolutePath())) {
-            return batchInstallBizInRequestStrategy;
+            return batchInstallBizInDirAbsolutePathStrategy;
         }
         return batchInstallBizInRequestStrategy;
     }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/UnifiedOperationServiceImpl.java
@@ -54,7 +54,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 public class UnifiedOperationServiceImpl implements UnifiedOperationService {
     private final BatchInstallStrategy batchInstallBizInDirAbsolutePathStrategy = new BatchInstallBizInDirAbsolutePathStrategy();
 
-    private final BatchInstallStrategy batchInstallBizInRequestStrategy = new BatchInstallBizInRequestStrategy();
+    private final BatchInstallStrategy batchInstallBizInRequestStrategy         = new BatchInstallBizInRequestStrategy();
 
     /** {@inheritDoc} */
     @Override
@@ -103,17 +103,18 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
         long startTimestamp = System.currentTimeMillis();
 
         BatchInstallStrategy batchInstallStrategy = getBatchInstallStrategy(request);
-        Map<Integer,List<InstallRequest>> installRequestsWithOrder = batchInstallStrategy.convertToInstallInput(request);
+        Map<Integer, List<InstallRequest>> installRequestsWithOrder = batchInstallStrategy
+            .convertToInstallInput(request);
 
         ThreadPoolExecutor executorService = ExecutorServiceManager.getArkBizOpsExecutor();
         Map<String, ClientResponse> bizUrlToInstallResult = new HashMap<>();
         boolean hasFailed = false;
-        for (Entry<Integer,List<InstallRequest>> entry : installRequestsWithOrder.entrySet()) {
+        for (Entry<Integer, List<InstallRequest>> entry : installRequestsWithOrder.entrySet()) {
             List<InstallRequest> bizRequestInSameOrder = entry.getValue();
             List<CompletableFuture<ClientResponse>> futures = new ArrayList<>();
             for (InstallRequest bizRequest : bizRequestInSameOrder) {
-                futures.add(CompletableFuture.supplyAsync(
-                    () -> safeBatchInstall(bizRequest), executorService));
+                futures.add(CompletableFuture.supplyAsync(() -> safeBatchInstall(bizRequest),
+                    executorService));
             }
 
             // wait for all install futures done
@@ -139,7 +140,7 @@ public class UnifiedOperationServiceImpl implements UnifiedOperationService {
     }
 
     private BatchInstallStrategy getBatchInstallStrategy(BatchInstallRequest request) {
-        if(StringUtil.isNotEmpty(request.getBizDirAbsolutePath())){
+        if (StringUtil.isNotEmpty(request.getBizDirAbsolutePath())) {
             return batchInstallBizInRequestStrategy;
         }
         return batchInstallBizInRequestStrategy;

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
 
@@ -24,15 +36,15 @@ import static com.alipay.sofa.koupleless.arklet.core.common.model.Constants.STRA
 public class BatchInstallBizInDirAbsolutePathStrategy implements BatchInstallStrategy {
     private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
 
-    private static final String installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
+    private static final String      installStrategy    = STRATEGY_INSTALL_ONLY_STRATEGY;
 
     @Override
-    public Map<Integer,List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
-        Map<Integer,List<InstallRequest>> result = new TreeMap<>();
+    public Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
+        Map<Integer, List<InstallRequest>> result = new TreeMap<>();
 
         Map<Integer, List<String>> bizUrls = batchInstallHelper
-                .getBizUrlsFromLocalFileSystem(request.getBizDirAbsolutePath());
-        for (Map.Entry<Integer, List<String>> entry : bizUrls.entrySet()){
+            .getBizUrlsFromLocalFileSystem(request.getBizDirAbsolutePath());
+        for (Map.Entry<Integer, List<String>> entry : bizUrls.entrySet()) {
             Integer order = entry.getKey();
             for (String bizUrl : entry.getValue()) {
                 result.putIfAbsent(order, new ArrayList<>());
@@ -42,14 +54,13 @@ public class BatchInstallBizInDirAbsolutePathStrategy implements BatchInstallStr
         return result;
     }
 
-    private InstallRequest buildInstallRequest(String bizAbsolutePath){
+    private InstallRequest buildInstallRequest(String bizAbsolutePath) {
         String bizUrl = OSUtils.getLocalFileProtocolPrefix() + bizAbsolutePath;
-        Map<String, Object> mainAttributes = batchInstallHelper
-                .getMainAttributes(bizAbsolutePath);
+        Map<String, Object> mainAttributes = batchInstallHelper.getMainAttributes(bizAbsolutePath);
         String bizName = (String) mainAttributes.get(Constants.ARK_BIZ_NAME);
         String bizVersion = (String) mainAttributes.get(Constants.ARK_BIZ_VERSION);
 
-        return InstallRequest.builder().bizUrl(bizUrl).bizName(bizName)
-                .bizVersion(bizVersion).installStrategy(installStrategy).build();
+        return InstallRequest.builder().bizUrl(bizUrl).bizName(bizName).bizVersion(bizVersion)
+            .installStrategy(installStrategy).build();
     }
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
@@ -34,15 +34,13 @@ import static com.alipay.sofa.koupleless.arklet.core.common.model.Constants.STRA
  * @version $Id: BatchInstallBizInDirStrategy.java, v 0.1 2024年12月18日 16:00 立蓬 Exp $
  */
 public class BatchInstallBizInDirAbsolutePathStrategy implements BatchInstallStrategy {
-    private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
-
-    private static final String      installStrategy    = STRATEGY_INSTALL_ONLY_STRATEGY;
+    private static final String installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
 
     @Override
     public Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
         Map<Integer, List<InstallRequest>> result = new TreeMap<>();
 
-        Map<Integer, List<String>> bizUrls = batchInstallHelper
+        Map<Integer, List<String>> bizUrls = BatchInstallHelper
             .getBizUrlsFromLocalFileSystem(request.getBizDirAbsolutePath());
         for (Map.Entry<Integer, List<String>> entry : bizUrls.entrySet()) {
             Integer order = entry.getKey();
@@ -56,7 +54,7 @@ public class BatchInstallBizInDirAbsolutePathStrategy implements BatchInstallStr
 
     private InstallRequest buildInstallRequest(String bizAbsolutePath) {
         String bizUrl = OSUtils.getLocalFileProtocolPrefix() + bizAbsolutePath;
-        Map<String, Object> mainAttributes = batchInstallHelper.getMainAttributes(bizAbsolutePath);
+        Map<String, Object> mainAttributes = BatchInstallHelper.getMainAttributes(bizAbsolutePath);
         String bizName = (String) mainAttributes.get(Constants.ARK_BIZ_NAME);
         String bizVersion = (String) mainAttributes.get(Constants.ARK_BIZ_VERSION);
 

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInDirAbsolutePathStrategy.java
@@ -1,0 +1,55 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
+
+import com.alipay.sofa.ark.spi.constant.Constants;
+import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.ops.BatchInstallHelper;
+import com.alipay.sofa.koupleless.common.util.OSUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static com.alipay.sofa.koupleless.arklet.core.common.model.Constants.STRATEGY_INSTALL_ONLY_STRATEGY;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: BatchInstallBizInDirStrategy.java, v 0.1 2024年12月18日 16:00 立蓬 Exp $
+ */
+public class BatchInstallBizInDirAbsolutePathStrategy implements BatchInstallStrategy {
+    private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
+
+    private static final String installStrategy = STRATEGY_INSTALL_ONLY_STRATEGY;
+
+    @Override
+    public Map<Integer,List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
+        Map<Integer,List<InstallRequest>> result = new TreeMap<>();
+
+        Map<Integer, List<String>> bizUrls = batchInstallHelper
+                .getBizUrlsFromLocalFileSystem(request.getBizDirAbsolutePath());
+        for (Map.Entry<Integer, List<String>> entry : bizUrls.entrySet()){
+            Integer order = entry.getKey();
+            for (String bizUrl : entry.getValue()) {
+                result.putIfAbsent(order, new ArrayList<>());
+                result.get(order).add(buildInstallRequest(bizUrl));
+            }
+        }
+        return result;
+    }
+
+    private InstallRequest buildInstallRequest(String bizAbsolutePath){
+        String bizUrl = OSUtils.getLocalFileProtocolPrefix() + bizAbsolutePath;
+        Map<String, Object> mainAttributes = batchInstallHelper
+                .getMainAttributes(bizAbsolutePath);
+        String bizName = (String) mainAttributes.get(Constants.ARK_BIZ_NAME);
+        String bizVersion = (String) mainAttributes.get(Constants.ARK_BIZ_VERSION);
+
+        return InstallRequest.builder().bizUrl(bizUrl).bizName(bizName)
+                .bizVersion(bizVersion).installStrategy(installStrategy).build();
+    }
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
@@ -1,0 +1,53 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
+
+import com.alipay.sofa.ark.api.ArkClient;
+import com.alipay.sofa.ark.common.util.FileUtils;
+import com.alipay.sofa.ark.spi.service.PriorityOrdered;
+import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.ops.BatchInstallHelper;
+import lombok.SneakyThrows;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: BatchInstallBizInRequestStrategy.java, v 0.1 2024年12月18日 16:54 立蓬 Exp $
+ */
+public class BatchInstallBizInRequestStrategy implements BatchInstallStrategy {
+
+    private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
+    @Override
+    public Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
+        Map<Integer,List<InstallRequest>> result = new TreeMap<>();
+        for (InstallRequest installRequest : request.getInstallRequests()){
+            Integer order = parsePriority(installRequest);
+            result.putIfAbsent(order, new ArrayList<>());
+            result.get(order).add(installRequest);
+        }
+        return result;
+    }
+
+    @SneakyThrows
+    private Integer parsePriority(InstallRequest installRequest){
+        URL url = new URL(installRequest.getBizUrl());
+        File bizFile = ArkClient.createBizSaveFile(installRequest.getBizName(), installRequest.getBizVersion());
+        FileUtils.copyInputStreamToFile(url.openStream(), bizFile);
+
+        Map<String, Object> mainAttributes = batchInstallHelper
+                .getMainAttributes(bizFile.getAbsolutePath());
+        org.apache.commons.io.FileUtils.deleteQuietly(bizFile);
+        return Integer.valueOf(
+                mainAttributes.getOrDefault("priority", PriorityOrdered.DEFAULT_PRECEDENCE)
+                        .toString());
+    }
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
@@ -37,8 +37,6 @@ import java.util.TreeMap;
  */
 public class BatchInstallBizInRequestStrategy implements BatchInstallStrategy {
 
-    private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
-
     @Override
     public Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
         Map<Integer, List<InstallRequest>> result = new TreeMap<>();
@@ -57,7 +55,7 @@ public class BatchInstallBizInRequestStrategy implements BatchInstallStrategy {
             installRequest.getBizVersion());
         FileUtils.copyInputStreamToFile(url.openStream(), bizFile);
 
-        Map<String, Object> mainAttributes = batchInstallHelper
+        Map<String, Object> mainAttributes = BatchInstallHelper
             .getMainAttributes(bizFile.getAbsolutePath());
         org.apache.commons.io.FileUtils.deleteQuietly(bizFile);
         return Integer.valueOf(

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallBizInRequestStrategy.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
 
@@ -26,10 +38,11 @@ import java.util.TreeMap;
 public class BatchInstallBizInRequestStrategy implements BatchInstallStrategy {
 
     private final BatchInstallHelper batchInstallHelper = new BatchInstallHelper();
+
     @Override
     public Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable {
-        Map<Integer,List<InstallRequest>> result = new TreeMap<>();
-        for (InstallRequest installRequest : request.getInstallRequests()){
+        Map<Integer, List<InstallRequest>> result = new TreeMap<>();
+        for (InstallRequest installRequest : request.getInstallRequests()) {
             Integer order = parsePriority(installRequest);
             result.putIfAbsent(order, new ArrayList<>());
             result.get(order).add(installRequest);
@@ -38,16 +51,16 @@ public class BatchInstallBizInRequestStrategy implements BatchInstallStrategy {
     }
 
     @SneakyThrows
-    private Integer parsePriority(InstallRequest installRequest){
+    private Integer parsePriority(InstallRequest installRequest) {
         URL url = new URL(installRequest.getBizUrl());
-        File bizFile = ArkClient.createBizSaveFile(installRequest.getBizName(), installRequest.getBizVersion());
+        File bizFile = ArkClient.createBizSaveFile(installRequest.getBizName(),
+            installRequest.getBizVersion());
         FileUtils.copyInputStreamToFile(url.openStream(), bizFile);
 
         Map<String, Object> mainAttributes = batchInstallHelper
-                .getMainAttributes(bizFile.getAbsolutePath());
+            .getMainAttributes(bizFile.getAbsolutePath());
         org.apache.commons.io.FileUtils.deleteQuietly(bizFile);
         return Integer.valueOf(
-                mainAttributes.getOrDefault("priority", PriorityOrdered.DEFAULT_PRECEDENCE)
-                        .toString());
+            mainAttributes.getOrDefault("priority", PriorityOrdered.DEFAULT_PRECEDENCE).toString());
     }
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallStrategy.java
@@ -1,0 +1,19 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
+
+import com.alipay.sofa.koupleless.arklet.core.common.model.BatchInstallRequest;
+import com.alipay.sofa.koupleless.arklet.core.common.model.InstallRequest;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: BatchInstallStrategy.java, v 0.1 2024年12月18日 16:00 立蓬 Exp $
+ */
+public interface BatchInstallStrategy {
+    Map<Integer,List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable;
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallStrategy.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/ops/strategy/BatchInstallStrategy.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.ops.strategy;
 
@@ -15,5 +27,5 @@ import java.util.Map;
  * @version $Id: BatchInstallStrategy.java, v 0.1 2024年12月18日 16:00 立蓬 Exp $
  */
 public interface BatchInstallStrategy {
-    Map<Integer,List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable;
+    Map<Integer, List<InstallRequest>> convertToInstallInput(BatchInstallRequest request) throws Throwable;
 }

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/util/ResourceUtils.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/util/ResourceUtils.java
@@ -1,0 +1,24 @@
+/**
+ * Alipay.com Inc.
+ * Copyright (c) 2004-2024 All Rights Reserved.
+ */
+package com.alipay.sofa.koupleless.arklet.core.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.util.List;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: ResourceUtils.java, v 0.1 2024年12月18日 15:32 立蓬 Exp $
+ */
+public class ResourceUtils {
+    public static MemoryPoolMXBean getMetaSpaceMXBean() {
+        MemoryPoolMXBean metaSpaceMXBean = null;
+        List<MemoryPoolMXBean> memoryPoolMXBeans = ManagementFactory.getMemoryPoolMXBeans();
+        for (MemoryPoolMXBean memoryPoolMXBean : memoryPoolMXBeans)
+            if (memoryPoolMXBean.getName().equals("Metaspace"))
+                metaSpaceMXBean = memoryPoolMXBean;
+        return metaSpaceMXBean;
+    }
+}

--- a/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/util/ResourceUtils.java
+++ b/arklet-core/src/main/java/com/alipay/sofa/koupleless/arklet/core/util/ResourceUtils.java
@@ -1,6 +1,18 @@
-/**
- * Alipay.com Inc.
- * Copyright (c) 2004-2024 All Rights Reserved.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.alipay.sofa.koupleless.arklet.core.util;
 

--- a/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
+++ b/arklet-core/src/test/java/com/alipay/sofa/koupleless/arklet/core/component/UnifiedOperationServiceImplTests.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.alipay.sofa.koupleless.arklet.core.common.model.Constants.STRATEGY_INSTALL_ONLY_STRATEGY;
 import static com.alipay.sofa.koupleless.arklet.core.common.model.Constants.STRATEGY_UNINSTALL_THEN_INSTALL;
@@ -182,10 +183,9 @@ public class UnifiedOperationServiceImplTests {
             BatchInstallResponse response = unifiedOperationService.batchInstall(
                 BatchInstallRequest.builder().bizDirAbsolutePath("/path/to/biz").build());
 
-            Assert.assertTrue(response.getBizUrlToResponse().containsKey("file:///file/a-biz.jar"));
-
-            Assert.assertTrue(response.getBizUrlToResponse().containsKey("file:///file/b-biz.jar"));
-
+            Set<String> bizUrls = response.getBizUrlToResponse().keySet();
+            Assert.assertTrue(bizUrls.stream().anyMatch(url -> url.endsWith("a-biz.jar")));
+            Assert.assertTrue(bizUrls.stream().anyMatch(url -> url.endsWith("b-biz.jar")));
         }
     }
 }

--- a/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/MqttMessageHandler.java
+++ b/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/MqttMessageHandler.java
@@ -241,22 +241,21 @@ public class MqttMessageHandler {
         ArkletLoggerFactory.getDefaultLogger()
             .info("start to playback baseline with content: " + cmdContent);
 
-        Output<BatchInstallResponse> output = null;
+        Output<?> output = null;
         try {
             output = commandService.process(BuiltinCommand.BATCH_INSTALL_BIZ.getId(), cmdContent);
         } catch (Throwable e) {
             ArkletLoggerFactory.getDefaultLogger().error(
-                    String.format("fail to handle command %s with content: %s", cmd, e.getMessage()));
+                String.format("fail to handle command %s with content: %s", cmd, e.getMessage()));
             return;
         }
 
         if (!output.failed()) {
             ArkletLoggerFactory.getDefaultLogger()
-                    .info("install biz success when playback baseline");
+                .info("install biz success when playback baseline");
         } else {
-            Map<String, ClientResponse> bizUrlToResponse = null == output.getData()?null:output.getData().getBizUrlToResponse();
-            ArkletLoggerFactory.getDefaultLogger().error(
-                    String.format("fail to handle command %s with content: %s", cmd, bizUrlToResponse));
+            ArkletLoggerFactory.getDefaultLogger()
+                .error("fail to handle command {} with content: {}", cmd, output);
         }
     }
 

--- a/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/handler/MsgHandler.java
+++ b/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/handler/MsgHandler.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.arklet.tunnel.mqtt.paho.handler;
+
+import com.alipay.sofa.koupleless.arklet.core.command.CommandService;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.BuiltinCommand;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
+import com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletRuntimeException;
+import com.alipay.sofa.koupleless.common.log.ArkletLoggerFactory;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.util.Map;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: MsgHandler.java, v 0.1 2024年12月30日 14:22 立蓬 Exp $
+ */
+public abstract class MsgHandler {
+
+    protected final CommandService commandService;
+
+    public MsgHandler(CommandService commandService) {
+        this.commandService = commandService;
+    }
+
+    public void handle(MqttMessage msg) {
+        Map<String, Object> cmdContent = toRequest(msg);
+        ArkletLoggerFactory.getDefaultLogger().info("start to handle mqtt cmd {} with content: {}",
+            getMqttCMD(), cmdContent);
+
+        Output<?> output = null;
+        try {
+            output = commandService.process(getArkletCommand().getId(), cmdContent);
+            pubSuccessMsg(output);
+        } catch (Throwable e) {
+            ArkletLoggerFactory.getDefaultLogger().error(String.format(
+                "fail to handle mqtt cmd %s with content: %s", getMqttCMD(), e.getMessage()));
+            pubThrowableMsg(e);
+            throw new ArkletRuntimeException(e);
+        }
+
+        ArkletLoggerFactory.getDefaultLogger()
+            .info("finished to handle mqtt cmd {} when with output: {}", getMqttCMD(), output);
+    }
+
+    abstract Map<String, Object> toRequest(MqttMessage msg);
+
+    abstract String getMqttCMD();
+
+    abstract BuiltinCommand getArkletCommand();
+
+    abstract void pubSuccessMsg(Output<?> output) throws Exception;
+
+    abstract void pubThrowableMsg(Throwable e);
+}

--- a/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/handler/PlaybackBaselineHandler.java
+++ b/arklet-tunnel-mqtt/src/main/java/com/alipay/sofa/koupleless/arklet/tunnel/mqtt/paho/handler/PlaybackBaselineHandler.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.arklet.tunnel.mqtt.paho.handler;
+
+import com.alibaba.fastjson.JSONObject;
+import com.alipay.sofa.ark.api.ClientResponse;
+import com.alipay.sofa.ark.api.ResponseCode;
+import com.alipay.sofa.koupleless.arklet.core.command.CommandService;
+import com.alipay.sofa.koupleless.arklet.core.command.builtin.BuiltinCommand;
+import com.alipay.sofa.koupleless.arklet.core.command.meta.Output;
+import com.alipay.sofa.koupleless.arklet.core.common.exception.ArkletRuntimeException;
+import com.alipay.sofa.koupleless.arklet.core.hook.base.BaseMetadataHook;
+import com.alipay.sofa.koupleless.arklet.core.util.ExceptionUtils;
+import com.alipay.sofa.koupleless.arklet.tunnel.mqtt.model.Constants;
+import com.alipay.sofa.koupleless.arklet.tunnel.mqtt.model.MqttResponse;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author lianglipeng.llp@alibaba-inc.com
+ * @version $Id: PlaybackBaselineHandler.java, v 0.1 2024年12月30日 14:21 立蓬 Exp $
+ */
+public class PlaybackBaselineHandler extends MsgHandler {
+    public static final String     Mqtt_CMD = "baseline";
+
+    private final MqttClient       mqttClient;
+
+    private final BaseMetadataHook baseMetadataHook;
+
+    private final String           baseEnv;
+
+    public PlaybackBaselineHandler(CommandService commandService, BaseMetadataHook baseMetadataHook,
+                                   MqttClient mqttClient, String baseEnv) {
+        super(commandService);
+        this.mqttClient = mqttClient;
+        this.baseMetadataHook = baseMetadataHook;
+        this.baseEnv = baseEnv;
+    }
+
+    @Override
+    protected String getMqttCMD() {
+        return Mqtt_CMD;
+    }
+
+    @Override
+    protected BuiltinCommand getArkletCommand() {
+        return BuiltinCommand.BATCH_INSTALL_BIZ;
+    }
+
+    @Override
+    protected void pubThrowableMsg(Throwable e) {
+        Map<String, Object> bizOperationResponse = failOfResponse(e);
+        try {
+            mqttClient.publish(getPubTopic(),
+                JSONObject.toJSONString(MqttResponse.withData(bizOperationResponse)).getBytes(), 1,
+                false);
+        } catch (MqttException ex) {
+            throw new ArkletRuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void pubSuccessMsg(Output<?> output) throws MqttException {
+        Map<String, Object> bizOperationResponse = successOfResponse(output);
+        mqttClient.publish(getPubTopic(),
+            JSONObject.toJSONString(MqttResponse.withData(bizOperationResponse)).getBytes(), 1,
+            false);
+    }
+
+    private String getPubTopic() {
+        return String.format("koupleless_%s/%s/base/batchInstallBizResponse", baseEnv,
+            baseMetadataHook.getIdentity());
+    }
+
+    @Override
+    public Map<String, Object> toRequest(MqttMessage msg) {
+        List<Map<String, Object>> cmdContents = JSONObject.parseObject(msg.toString(), List.class);
+        Map<String, Object> cmdContent = new HashMap<>();
+        cmdContent.put("bizList", cmdContents);
+        return cmdContent;
+    }
+
+    /**
+     * success mqtt response like:
+     * { "command" -> "batchInstallBiz" }
+     * { "response" -> output }
+     * @return java.util.Map<java.lang.String,java.lang.Object>
+     */
+    private Map<String, Object> successOfResponse(Output<?> output) {
+        Map<String, Object> bizOperationResponse = new HashMap<>();
+        bizOperationResponse.put(Constants.COMMAND, getArkletCommand().getId());
+        bizOperationResponse.put(Constants.COMMAND_RESPONSE, output);
+        return bizOperationResponse;
+    }
+
+    /**
+     * failed mqtt response like:
+     * { "command" -> "batchInstallBiz" }
+     * { "response" -> output }
+     * @return java.util.Map<java.lang.String,java.lang.Object>
+     */
+    private Map<String, Object> failOfResponse(Throwable e) {
+        ClientResponse data = new ClientResponse();
+        data.setMessage(ExceptionUtils.getStackTraceAsString(e));
+        data.setCode(ResponseCode.FAILED);
+        Output<?> output = Output.ofFailed(data, e.getMessage());
+
+        Map<String, Object> bizOperationResponse = new HashMap<>();
+        bizOperationResponse.put(Constants.COMMAND, getArkletCommand().getId());
+        bizOperationResponse.put(Constants.COMMAND_RESPONSE, output);
+        return bizOperationResponse;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.4.0</revision>
+        <revision>1.4.1-SNAPSHOT</revision>
         <sofa.ark.version>2.2.16</sofa.ark.version>
         <koupleless.runtime.version>${revision}</koupleless.runtime.version>
         <spring.boot.version>2.7.15</spring.boot.version>


### PR DESCRIPTION
新增批量安装模块的 handler，基线回放的功能应该通过实现 `com.alipay.sofa.ark.spi.service.biz.AddBizToStaticDeployHook` 接口来实现
fix: https://github.com/koupleless/koupleless/issues/361

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced batch installation functionality with new command options and handlers.
	- Added support for processing multiple installation requests in a batch format.
	- Implemented a modular command handling structure for MQTT messages.

- **Bug Fixes**
	- Improved error handling and logging for batch installation commands.

- **Documentation**
	- Updated versioning information in the project configuration.

- **Chores**
	- Corrected a typographical error in the project configuration file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->