### PR TITLE
静态部署，配置的远程URL为http或https时，新增Basic认证

### DIFF
--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/pom.xml
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/pom.xml
@@ -98,6 +98,10 @@
             <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/constant/Constants.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/constant/Constants.java
@@ -25,39 +25,48 @@ import java.io.File;
  * @version $Id: Constants.java, v 0.1 2024年06月26日 11:29 立蓬 Exp $
  */
 public class Constants {
+
     /**
      * String Constants
      */
-    public final static String COMMA_SPLIT                    = ",";
+    public final static String COMMA_SPLIT                          = ",";
 
-    public static final String FILE_PREFIX                    = OSUtils
+    public static final String FILE_PREFIX                          = OSUtils
         .getLocalFileProtocolPrefix();
-    public static final String HTTP_PREFIX                    = "http://";
+    public static final String HTTP_PREFIX                          = "http://";
 
-    public static final String HTTPS_PREFIX                   = "https://";
+    public static final String HTTPS_PREFIX                         = "https://";
+
+    public static final String AUTHORIZATION_BASIC                  = "Basic";
 
     /**
      * ark.conf
      */
-    public final static String ARK_CONF_BASE_DIR              = "conf/ark";
-    public final static String ARK_PROPERTIES_FILE            = "bootstrap.properties";
+    public final static String ARK_CONF_BASE_DIR                    = "conf/ark";
+    public final static String ARK_PROPERTIES_FILE                  = "bootstrap.properties";
 
-    public final static String ARK_YML_FILE                   = "bootstrap.yml";
+    public final static String ARK_YML_FILE                         = "bootstrap.yml";
 
-    public final static String SOFA_ARK_MODULE                = "SOFA-ARK" + File.separator + "biz";
+    public final static String SOFA_ARK_MODULE                      = "SOFA-ARK" + File.separator
+        + "biz";
 
     /**
      * extension-config
      */
-    public final static String EXTENSION_INTEGRATE_URLS       = "integrateBizURLs";
+    public final static String EXTENSION_INTEGRATE_URLS             = "integrateBizURLs";
 
-    public final static String EXTENSION_INTEGRATE_LOCAL_DIRS = "integrateLocalDirs";
+    public final static String INTEGRATE_BIZ_URL                    = "integrateBizURL";
+    public final static String INTEGRATE_BIZ_URL_AUTHORIZATION_TYPE = "integrateBizURL.authorizationType";
+    public final static String INTEGRATE_BIZ_URL_BASIC_USERNAME     = "integrateBizURL.basicUsername";
+    public final static String INTEGRATE_BIZ_URL_BASIC_PASSWORD     = "integrateBizURL.basicPassword";
+
+    public final static String EXTENSION_INTEGRATE_LOCAL_DIRS       = "integrateLocalDirs";
 
     /**
      * tag
      */
-    public final static String PACKAGE_PREFIX_MARK            = "*";
+    public final static String PACKAGE_PREFIX_MARK                  = "*";
 
-    public final static String STRING_COLON                   = ":";
+    public final static String STRING_COLON                         = ":";
 
 }

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/constant/Constants.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/constant/Constants.java
@@ -48,7 +48,7 @@ public class Constants {
     public final static String ARK_YML_FILE                         = "bootstrap.yml";
 
     public final static String SOFA_ARK_MODULE                      = "SOFA-ARK" + File.separator
-        + "biz";
+                                                                      + "biz";
 
     /**
      * extension-config

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/model/KouplelessIntegrateBizConfig.java
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/main/java/com/alipay/sofa/koupleless/base/build/plugin/model/KouplelessIntegrateBizConfig.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.HashSet;
 import java.util.Set;
+import lombok.Setter;
 
 /**
  * @author lianglipeng.llp@alibaba-inc.com
@@ -33,16 +34,22 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Setter
 public class KouplelessIntegrateBizConfig {
     /**
      * 指定文件URL，将拷贝到 classpath 下的 SOFA-ARK/biz，支持：file:///,http://, https://
      */
-    Set<String> fileURLs  = new HashSet<>();
+    Set<String>                                 fileURLs  = new HashSet<>();
 
     /**
      * 指定本地目录，将拷贝该目录下的所有 ark-biz 到 classpath 下的 SOFA-ARK/biz
      */
-    Set<String> localDirs = new HashSet<>();
+    Set<String>                                 localDirs = new HashSet<>();
+
+    /**
+     * http、https header的Authorization配置
+     */
+    private KouplelessIntegrateBizAuthorization httpAuthorization;
 
     public void addFileURLs(Set<String> urls) {
         fileURLs.addAll(urls);
@@ -50,5 +57,24 @@ public class KouplelessIntegrateBizConfig {
 
     public void addLocalDirs(Set<String> absolutePath) {
         localDirs.addAll(absolutePath);
+    }
+
+    @Getter
+    @Setter
+    public static class KouplelessIntegrateBizAuthorization {
+        /**
+         * http、https header的Authorization类型
+         */
+        String authorizationType;
+
+        /**
+         * authorizationType为basic类型时，用户名
+         */
+        String basicUsername;
+
+        /**
+         * authorizationType为basic类型时，密码
+         */
+        String basicPassword;
     }
 }

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/test/resources/mockBaseDir/conf/ark/bootstrap.properties
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/test/resources/mockBaseDir/conf/ark/bootstrap.properties
@@ -2,3 +2,6 @@ integrateBizURLs=file:///bbb.jar,\
   file:///ccc.jar
 integrateLocalDirs=/mock/B,\  \
   /mock/C
+integrateBizURL.authorizationType=Basic
+integrateBizURL.basicUsername=properties-test
+integrateBizURL.basicPassword=properties-test

--- a/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/test/resources/mockBaseDir/conf/ark/bootstrap.yml
+++ b/koupleless-ext/koupleless-build-plugin/koupleless-base-build-plugin/src/test/resources/mockBaseDir/conf/ark/bootstrap.yml
@@ -3,3 +3,7 @@ integrateBizURLs:
 integrateLocalDirs:
   - /aaa
   - /bbb
+integrateBizURL:
+  authorizationType: Basic
+  basicUsername: yml-test
+  basicPassword: yml-test


### PR DESCRIPTION
通过在基座的conf/ark/bootstrap.yml文件添加以下配置开启basic认证，不配置时，默认为没有认证访问
```yml
integrateBizURL:
  authorizationType: Basic
  basicUsername: yml-test
  basicPassword: yml-test
```
或者在基座的 conf/ark/bootstrap.properties文件添加以下配置开启basic认证，不配置时，默认为没有认证访问
```yml
integrateBizURL.authorizationType=Basic
integrateBizURL.basicUsername=properties-test
integrateBizURL.basicPassword=properties-test
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP authorization (Basic authentication) when downloading integration business files from HTTP/HTTPS URLs.
  - Authorization credentials can now be configured via both YAML and properties files.

- **Documentation**
  - Updated sample configuration files to demonstrate new authorization options for integration URLs.

- **Chores**
  - Added a new dependency for JSON processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->